### PR TITLE
Add local fallback for scraping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore generated HTML files and logs
+*_spells.html
+run.log
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# EQDataScraper
+
+This script retrieves spell data for each EverQuest class from the Clumsy's World Allakhazam clone. It generates one HTML file per class showing the spell table with a simple colour theme.
+
+By default the script fetches spell tables directly from the Clumsy's World site. If the
+site is unreachable you can provide a directory of HTML files using `--local-dir`.
+Each file should be named `<class>.html` (e.g. `bard.html`). A generic
+`sample_table.html` is provided for testing and will be used for any missing class file.
+
+## Usage
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run once:
+
+```bash
+python3 scrape_spells.py
+```
+
+Run continually every hour:
+
+```bash
+python3 scrape_spells.py --loop --interval 3600
+```
+
+Use local HTML files instead of fetching:
+
+```bash
+python3 scrape_spells.py --local-dir samples
+```
+
+Specify an alternate base URL:
+
+```bash
+python3 scrape_spells.py --base-url https://my-mirror.example.com/
+```
+
+Generated HTML files will appear in the project directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+requests
+pandas
+beautifulsoup4
+jinja2
+lxml

--- a/samples/sample_table.html
+++ b/samples/sample_table.html
@@ -1,0 +1,4 @@
+<table>
+<tr><th>Name</th><th>Mana</th></tr>
+<tr><td>Sample Spell</td><td>10</td></tr>
+</table>

--- a/scrape_spells.py
+++ b/scrape_spells.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
-import os, time, requests, pandas as pd
+import os
+import time
+import argparse
+from typing import Dict, Optional
+
+import requests
+import pandas as pd
 from bs4 import BeautifulSoup
 from jinja2 import Template
 
 # 🎯 Full list of classes with their type IDs
-CLASSES = {
+CLASSES: Dict[str, int] = {
     'Warrior': 1,
     'Cleric': 2,
     'Paladin': 3,
@@ -23,25 +29,74 @@ CLASSES = {
     'Berserker': 16,
 }
 
+# Basic colour theme for each class used in the generated HTML. This is far from
+# accurate to the game's palette but provides a quick way to differentiate the
+# pages when rendered.
+CLASS_COLORS: Dict[str, str] = {
+    'Warrior': '#8e2d2d',
+    'Cleric': '#ccccff',
+    'Paladin': '#ffd700',
+    'Ranger': '#228b22',
+    'ShadowKnight': '#551a8b',
+    'Druid': '#a0522d',
+    'Monk': '#556b2f',
+    'Bard': '#ff69b4',
+    'Rogue': '#708090',
+    'Shaman': '#20b2aa',
+    'Necromancer': '#4b0082',
+    'Wizard': '#1e90ff',
+    'Magician': '#ff8c00',
+    'Enchanter': '#9370db',
+    'Beastlord': '#a52a2a',
+    'Berserker': '#b22222',
+}
+
 BASE_URL = 'https://alla.clumsysworld.com/'
 HTML_TEMPLATE = """
-<!DOCTYPE html><html><head><meta charset="utf-8">
-<title>{{ cls }} Spells</title>
-<style>
-  body { font-family: sans-serif; background: #f0f0f0; padding: 20px; }
-  h1 { color: #333; }
-  table { width:100%; border-collapse: collapse; }
-  th, td { padding: 6px; border: 1px solid #888; text-align: left; }
-  tr:nth-child(even) { background: #eee; }
-</style></head>
-<body><h1>{{ cls }} Spells</h1>
-{{ table|safe }}</body></html>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <title>{{ cls }} Spells</title>
+    <style>
+        body { font-family: sans-serif; background: #f0f0f0; padding: 20px; }
+        h1 { color: {{ color }}; }
+        table { width: 100%%; border-collapse: collapse; }
+        th, td { padding: 6px; border: 1px solid #888; text-align: left; }
+        tr:nth-child(even) { background: #eee; }
+    </style>
+</head>
+<body>
+    <h1>{{ cls }} Spells</h1>
+    {{ table|safe }}
+</body>
+</html>
 """
 
-def fetch_spell_html(class_type: int) -> str:
-    resp = requests.get(BASE_URL, params={'a':'spells','name':'','type':class_type,'level':1,'opt':2})
+def fetch_spell_html(class_type: int, base_url: str = BASE_URL) -> str:
+    """Fetch HTML for a class's spells from the remote site."""
+
+    resp = requests.get(
+        base_url,
+        params={"a": "spells", "name": "", "type": class_type, "level": 1, "opt": 2},
+        timeout=10,
+    )
     resp.raise_for_status()
     return resp.text
+
+def read_local_spell_html(cls: str, local_dir: str) -> Optional[str]:
+    """Return HTML from a local file if present."""
+
+    path = os.path.join(local_dir, f"{cls.lower()}.html")
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+    # Fallback to a generic sample if available
+    sample = os.path.join(local_dir, "sample_table.html")
+    if os.path.exists(sample):
+        with open(sample, "r", encoding="utf-8") as f:
+            return f.read()
+    return None
 
 def parse_spell_table(html: str) -> pd.DataFrame:
     from io import StringIO
@@ -52,23 +107,45 @@ def parse_spell_table(html: str) -> pd.DataFrame:
     return pd.read_html(StringIO(str(tbl)))[0]
 
 def render_html(df: pd.DataFrame, cls: str) -> str:
-    return Template(HTML_TEMPLATE).render(cls=cls, table=df.to_html(index=False))
+    color = CLASS_COLORS.get(cls, "#333")
+    return Template(HTML_TEMPLATE).render(cls=cls, table=df.to_html(index=False), color=color)
 
-def process_all_classes():
+def process_all_classes(base_url: str = BASE_URL, local_dir: Optional[str] = None) -> None:
+    """Fetch and render spell tables for every class."""
     for cls, ctype in CLASSES.items():
         try:
-            html = fetch_spell_html(ctype)
+            html = None
+            if local_dir:
+                html = read_local_spell_html(cls, local_dir)
+            if html is None:
+                html = fetch_spell_html(ctype, base_url)
             df = parse_spell_table(html)
             out = render_html(df, cls)
             fname = os.path.join(os.path.dirname(__file__), f"{cls.lower()}_spells.html")
-            with open(fname, 'w', encoding='utf-8') as f:
+            with open(fname, "w", encoding="utf-8") as f:
                 f.write(out)
             print(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] ✅ {fname}")
         except Exception as e:
             print(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] ❌ {cls}: {e}")
 
-def main():
-    process_all_classes()
+def run(loop: bool = False, interval: int = 3600, base_url: str = BASE_URL, local_dir: Optional[str] = None) -> None:
+    """Run the scraping process once or continually."""
+    while True:
+        process_all_classes(base_url=base_url, local_dir=local_dir)
+        if not loop:
+            break
+        time.sleep(interval)
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Scrape Clumsy's World spell tables")
+    parser.add_argument("--loop", action="store_true", help="continually scrape on an interval")
+    parser.add_argument("--interval", type=int, default=3600, help="seconds between scrapes when looping")
+    parser.add_argument("--base-url", default=BASE_URL, help="alternate base URL for fetching spell tables")
+    parser.add_argument("--local-dir", help="read HTML files from this directory instead of fetching")
+    args = parser.parse_args()
+
+    run(loop=args.loop, interval=args.interval, base_url=args.base_url, local_dir=args.local_dir)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- support specifying `--base-url` and `--local-dir` for alternate spell sources
- provide sample HTML table for offline testing
- document new options in README

## Testing
- `pip install -r requirements.txt`
- `python3 scrape_spells.py --local-dir samples > /tmp/run.log && tail -n 2 /tmp/run.log`


------
https://chatgpt.com/codex/tasks/task_e_68533e43696c8322a106cd8a36581cbd