### PR TITLE
Add Vue integration for spell pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ The script pulls data directly from `https://alla.clumsysworld.com/` by default,
 - The packages listed in `requirements.txt`
 
 Install the dependencies with:
+```bash
+pip install -r requirements.txt
+```
 
 This script retrieves spell data for each EverQuest class from the Clumsy's World Allakhazam clone. It generates one HTML file per class showing the spell table with a simple colour theme.
 
@@ -20,19 +23,14 @@ Each file should be named `<class>.html` (e.g. `bard.html`). A generic
 
 ## Usage
 
-Install dependencies:
-```bash
-pip install -r requirements.txt
-```
-
-
-## Basic usage
+### Basic usage
 Execute the scraper once for all classes:
-Run once:
 ```bash
 python scrape_spells.py
 ```
 When finished you will find HTML files such as `bard_spells.html`, `cleric_spells.html` and so on in the repository folder. Open any of these files in your browser to view the results.
+
+Alternatively open `index.html` in your browser to use the new Vue‑powered interface which links to every generated spell page. The individual spell pages themselves now also use Vue 3 for smooth navigation.
 
 ## Running continuously
 The script can run in a loop to keep your local files up‑to‑date. Use `--loop` together with an optional `--interval` (seconds) to control how often it runs. The example below scrapes every hour:

--- a/index.html
+++ b/index.html
@@ -248,9 +248,6 @@
             position: relative;
         }
         
-        .class-icon.fallback {
-            font-family: 'Cinzel', serif;
-        }
         
         @keyframes float {
             0%, 100% { transform: translateY(0px) rotateY(0deg); }
@@ -328,125 +325,49 @@
     </style>
 </head>
 <body>
-    <div class="main-container">
+    <div id="app" class="main-container">
         <div class="hero-section">
             <h1 class="main-title">Clumsy's World</h1>
             <p class="main-subtitle">Class Information</p>
         </div>
-        
+
         <div class="classes-grid">
-            <a href="warrior_spells.html" class="class-card warrior">
+            <a v-for="cls in classes" :key="cls.slug" :href="cls.file" :class="['class-card', cls.slug]">
                 <div class="class-icon">
-                    <img src="icons/warrior.gif" alt="Warrior" onerror="this.src='https://wiki.heroesjourneyemu.com/classes-and-abilities/warrior.gif'; this.onerror=function(){this.style.display='none';};">
+                    <img :src="cls.icon" :alt="cls.name">
                 </div>
-                <div class="class-name">Warrior</div>
+                <div class="class-name">{{ cls.name }}</div>
             </a>
-            
-            <a href="cleric_spells.html" class="class-card cleric">
-                <div class="class-icon">
-                    <img src="icons/cleric.gif" alt="Cleric" onerror="this.src='https://wiki.heroesjourneyemu.com/cleric.gif'; this.onerror=function(){this.style.display='none';};">
-                </div>
-                <div class="class-name">Cleric</div>
-            </a>
-            
-            <a href="paladin_spells.html" class="class-card paladin">
-                <div class="class-icon">
-                    <img src="icons/paladin.gif" alt="Paladin" onerror="this.src='https://wiki.heroesjourneyemu.com/paladin.gif'; this.onerror=function(){this.style.display='none';};">
-                </div>
-                <div class="class-name">Paladin</div>
-            </a>
-            
-            <a href="ranger_spells.html" class="class-card ranger">
-                <div class="class-icon">
-                    <img src="icons/ranger.gif" alt="Ranger" onerror="this.src='https://wiki.heroesjourneyemu.com/ranger.gif'; this.onerror=function(){this.style.display='none';};">
-                </div>
-                <div class="class-name">Ranger</div>
-            </a>
-            
-            <a href="shadowknight_spells.html" class="class-card shadowknight">
-                <div class="class-icon">
-                    <img src="icons/shadowknight.gif" alt="Shadow Knight" onerror="this.src='https://wiki.heroesjourneyemu.com/shadowknight.gif'; this.onerror=function(){this.style.display='none';};">
-                </div>
-                <div class="class-name">Shadow Knight</div>
-            </a>
-            
-            <a href="druid_spells.html" class="class-card druid">
-                <div class="class-icon">
-                    <img src="icons/druid.gif" alt="Druid" onerror="this.src='https://wiki.heroesjourneyemu.com/druid.gif'; this.onerror=function(){this.style.display='none';};">
-                </div>
-                <div class="class-name">Druid</div>
-            </a>
-            
-            <a href="monk_spells.html" class="class-card monk">
-                <div class="class-icon">
-                    <img src="icons/monk.gif" alt="Monk" onerror="this.src='https://wiki.heroesjourneyemu.com/monk.gif'; this.onerror=function(){this.style.display='none';};">
-                </div>
-                <div class="class-name">Monk</div>
-            </a>
-            
-            <a href="bard_spells.html" class="class-card bard">
-                <div class="class-icon">
-                    <img src="icons/bard.gif" alt="Bard" onerror="this.src='https://wiki.heroesjourneyemu.com/bard.gif'; this.onerror=function(){this.style.display='none';};">
-                </div>
-                <div class="class-name">Bard</div>
-            </a>
-            
-            <a href="rogue_spells.html" class="class-card rogue">
-                <div class="class-icon">
-                    <img src="icons/rogue.gif" alt="Rogue" onerror="this.src='https://wiki.heroesjourneyemu.com/classes-and-abilities/rogue.gif'; this.onerror=function(){this.style.display='none';};">
-                </div>
-                <div class="class-name">Rogue</div>
-            </a>
-            
-            <a href="shaman_spells.html" class="class-card shaman">
-                <div class="class-icon">
-                    <img src="icons/shaman.gif" alt="Shaman" onerror="this.src='https://wiki.heroesjourneyemu.com/shaman.gif'; this.onerror=function(){this.style.display='none';};">
-                </div>
-                <div class="class-name">Shaman</div>
-            </a>
-            
-            <a href="necromancer_spells.html" class="class-card necromancer">
-                <div class="class-icon">
-                    <img src="icons/necromancer.gif" alt="Necromancer" onerror="this.src='https://wiki.heroesjourneyemu.com/necromancer.gif'; this.onerror=function(){this.style.display='none';};">
-                </div>
-                <div class="class-name">Necromancer</div>
-            </a>
-            
-            <a href="wizard_spells.html" class="class-card wizard">
-                <div class="class-icon">
-                    <img src="icons/wizard.gif" alt="Wizard" onerror="this.src='https://wiki.heroesjourneyemu.com/wizard.gif'; this.onerror=function(){this.style.display='none';};">
-                </div>
-                <div class="class-name">Wizard</div>
-            </a>
-            
-            <a href="magician_spells.html" class="class-card magician">
-                <div class="class-icon">
-                    <img src="icons/magician.gif" alt="Magician" onerror="this.src='https://wiki.heroesjourneyemu.com/magician.gif'; this.onerror=function(){this.style.display='none';};">
-                </div>
-                <div class="class-name">Magician</div>
-            </a>
-            
-            <a href="enchanter_spells.html" class="class-card enchanter">
-                <div class="class-icon">
-                    <img src="icons/enchanter.gif" alt="Enchanter" onerror="this.src='https://wiki.heroesjourneyemu.com/enchanter.gif'; this.onerror=function(){this.style.display='none';};">
-                </div>
-                <div class="class-name">Enchanter</div>
-            </a>
-            
-            <a href="beastlord_spells.html" class="class-card beastlord">
-                <div class="class-icon">
-                    <img src="icons/beastlord.gif" alt="Beastlord" onerror="this.src='https://wiki.heroesjourneyemu.com/beastlord.gif'; this.onerror=function(){this.style.display='none';};">
-                </div>
-                <div class="class-name">Beastlord</div>
-            </a>
-            
-            <a href="berserker_spells.html" class="class-card berserker">
-                <div class="class-icon">
-                    <img src="icons/berserker.gif" alt="Berserker" onerror="this.src='https://wiki.heroesjourneyemu.com/berserker.gif'; this.onerror=function(){this.style.display='none';};">
-                </div>
-                <div class="class-name">Berserker</div>
-            </a>
+
         </div>
+        <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+        <script>
+        const { createApp } = Vue;
+        createApp({
+            data() {
+                return {
+                    classes: [
+                        { slug: 'warrior', name: 'Warrior', file: 'warrior_spells.html', icon: 'icons/warrior.gif' },
+                        { slug: 'cleric', name: 'Cleric', file: 'cleric_spells.html', icon: 'icons/cleric.gif' },
+                        { slug: 'paladin', name: 'Paladin', file: 'paladin_spells.html', icon: 'icons/paladin.gif' },
+                        { slug: 'ranger', name: 'Ranger', file: 'ranger_spells.html', icon: 'icons/ranger.gif' },
+                        { slug: 'shadowknight', name: 'Shadow Knight', file: 'shadowknight_spells.html', icon: 'icons/shadowknight.gif' },
+                        { slug: 'druid', name: 'Druid', file: 'druid_spells.html', icon: 'icons/druid.gif' },
+                        { slug: 'monk', name: 'Monk', file: 'monk_spells.html', icon: 'icons/monk.gif' },
+                        { slug: 'bard', name: 'Bard', file: 'bard_spells.html', icon: 'icons/bard.gif' },
+                        { slug: 'rogue', name: 'Rogue', file: 'rogue_spells.html', icon: 'icons/rogue.gif' },
+                        { slug: 'shaman', name: 'Shaman', file: 'shaman_spells.html', icon: 'icons/shaman.gif' },
+                        { slug: 'necromancer', name: 'Necromancer', file: 'necromancer_spells.html', icon: 'icons/necromancer.gif' },
+                        { slug: 'wizard', name: 'Wizard', file: 'wizard_spells.html', icon: 'icons/wizard.gif' },
+                        { slug: 'magician', name: 'Magician', file: 'magician_spells.html', icon: 'icons/magician.gif' },
+                        { slug: 'enchanter', name: 'Enchanter', file: 'enchanter_spells.html', icon: 'icons/enchanter.gif' },
+                        { slug: 'beastlord', name: 'Beastlord', file: 'beastlord_spells.html', icon: 'icons/beastlord.gif' },
+                        { slug: 'berserker', name: 'Berserker', file: 'berserker_spells.html', icon: 'icons/berserker.gif' }
+                    ]
+                };
+            }
+        }).mount('#app');
+        </script>
     </div>
 </body>
 </html>

--- a/scrape_spells.py
+++ b/scrape_spells.py
@@ -766,7 +766,7 @@ HTML_TEMPLATE = """
     </style>
 </head>
 <body>
-    <div class="main-container">
+    <div id="app" class="main-container">
         <div class="hero-section">
             <a href="index.html" class="home-button">Home</a>
             <h1 class="class-title">{{ cls }}</h1>
@@ -802,158 +802,136 @@ HTML_TEMPLATE = """
     <div id="copyPopup" class="copy-popup">
         Spell ID copied to clipboard!
     </div>
-    
+
+    <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
     <script>
-        let isScrolling = false;
-        let scrollTimeout;
-        
-        // Initialize level navigation matrix
-        function initializeLevelMatrix() {
-            const matrix = document.getElementById('levelMatrix');
-            const availableLevels = new Set();
-            
-            // Find all level sections on the page
-            const levelSections = document.querySelectorAll('.level-section');
-            levelSections.forEach(section => {
-                const levelTitle = section.querySelector('.level-title');
-                if (levelTitle) {
-                    const levelMatch = levelTitle.textContent.match(/Level (\\d+)/);
-                    if (levelMatch) {
-                        availableLevels.add(parseInt(levelMatch[1]));
-                    }
-                }
-            });
-            
-            // Create 60 level cells (10x6 grid)
-            for (let i = 1; i <= 60; i++) {
-                const cell = document.createElement('div');
-                cell.className = 'level-cell';
-                cell.textContent = String(i);
-                cell.setAttribute('data-level', String(i));
-                
-                // Mark available levels
-                if (availableLevels.has(i)) {
-                    cell.classList.add('available');
-                    cell.style.cursor = 'pointer';
-                    cell.addEventListener('click', () => scrollToLevel(i));
-                } else {
-                    cell.classList.add('disabled');
-                    cell.style.cursor = 'not-allowed';
-                    cell.title = `No spells available at level ${i}`;
-                }
-                
-                matrix.appendChild(cell);
-            }
-        }
-        
-        // Apply blur effect during scrolling
-        function applyScrollBlur() {
-            if (!isScrolling) {
-                isScrolling = true;
-                document.body.classList.add('scroll-blur');
-            }
-            
-            // Clear existing timeout
-            clearTimeout(scrollTimeout);
-            
-            // Remove blur after scrolling stops
-            scrollTimeout = setTimeout(() => {
-                isScrolling = false;
-                document.body.classList.remove('scroll-blur');
-            }, 150);
-        }
-        
-        // Scroll to a specific level section
-        function scrollToLevel(level) {
-            const levelSections = document.querySelectorAll('.level-section');
-            
-            for (const section of levelSections) {
-                const levelTitle = section.querySelector('.level-title');
-                if (levelTitle) {
-                    const levelMatch = levelTitle.textContent.match(/Level (\\d+)/);
-                    if (levelMatch && parseInt(levelMatch[1]) === level) {
-                        // Apply blur effect before scrolling
-                        applyScrollBlur();
-                        
-                        section.scrollIntoView({
-                            behavior: 'smooth',
-                            block: 'start'
-                        });
-                        
-                        // Add a temporary highlight effect after blur clears
-                        setTimeout(() => {
-                            const levelHeader = section.querySelector('.level-header');
-                            if (levelHeader) {
-                                levelHeader.style.transform = 'scale(1.02)';
-                                levelHeader.style.boxShadow = '0 0 30px rgba(var(--primary-rgb), 0.6)';
-                                setTimeout(() => {
-                                    levelHeader.style.transform = '';
-                                    levelHeader.style.boxShadow = '';
-                                }, 1000);
+        const { createApp } = Vue;
+        createApp({
+            data() {
+                return {
+                    isScrolling: false,
+                    scrollTimeout: null
+                };
+            },
+            methods: {
+                initializeLevelMatrix() {
+                    const matrix = document.getElementById('levelMatrix');
+                    const availableLevels = new Set();
+
+                    const levelSections = document.querySelectorAll('.level-section');
+                    levelSections.forEach(section => {
+                        const levelTitle = section.querySelector('.level-title');
+                        if (levelTitle) {
+                            const match = levelTitle.textContent.match(/Level (\\d+)/);
+                            if (match) {
+                                availableLevels.add(parseInt(match[1]));
                             }
-                        }, 300);
-                        break;
+                        }
+                    });
+
+                    for (let i = 1; i <= 60; i++) {
+                        const cell = document.createElement('div');
+                        cell.className = 'level-cell';
+                        cell.textContent = String(i);
+                        cell.setAttribute('data-level', String(i));
+
+                        if (availableLevels.has(i)) {
+                            cell.classList.add('available');
+                            cell.style.cursor = 'pointer';
+                            cell.addEventListener('click', () => this.scrollToLevel(i));
+                        } else {
+                            cell.classList.add('disabled');
+                            cell.style.cursor = 'not-allowed';
+                            cell.title = `No spells available at level ${i}`;
+                        }
+
+                        matrix.appendChild(cell);
                     }
+                },
+                applyScrollBlur() {
+                    if (!this.isScrolling) {
+                        this.isScrolling = true;
+                        document.body.classList.add('scroll-blur');
+                    }
+
+                    clearTimeout(this.scrollTimeout);
+
+                    this.scrollTimeout = setTimeout(() => {
+                        this.isScrolling = false;
+                        document.body.classList.remove('scroll-blur');
+                    }, 150);
+                },
+                scrollToLevel(level) {
+                    const levelSections = document.querySelectorAll('.level-section');
+
+                    for (const section of levelSections) {
+                        const levelTitle = section.querySelector('.level-title');
+                        if (levelTitle) {
+                            const match = levelTitle.textContent.match(/Level (\\d+)/);
+                            if (match && parseInt(match[1]) === level) {
+                                this.applyScrollBlur();
+
+                                section.scrollIntoView({
+                                    behavior: 'smooth',
+                                    block: 'start'
+                                });
+
+                                setTimeout(() => {
+                                    const levelHeader = section.querySelector('.level-header');
+                                    if (levelHeader) {
+                                        levelHeader.style.transform = 'scale(1.02)';
+                                        levelHeader.style.boxShadow = '0 0 30px rgba(var(--primary-rgb), 0.6)';
+                                        setTimeout(() => {
+                                            levelHeader.style.transform = '';
+                                            levelHeader.style.boxShadow = '';
+                                        }, 1000);
+                                    }
+                                }, 300);
+                                break;
+                            }
+                        }
+                    }
+                },
+                scrollToTop() {
+                    this.applyScrollBlur();
+                    window.scrollTo({
+                        top: 0,
+                        behavior: 'smooth'
+                    });
+                },
+                copySpellId(spellId) {
+                    navigator.clipboard.writeText(spellId).then(() => {
+                        const popup = document.getElementById('copyPopup');
+                        popup.textContent = `Spell ID ${spellId} copied to clipboard!`;
+                        popup.classList.add('show');
+                        setTimeout(() => {
+                            popup.classList.remove('show');
+                        }, 2000);
+                    }).catch(() => {
+                        const textArea = document.createElement('textarea');
+                        textArea.value = spellId;
+                        document.body.appendChild(textArea);
+                        textArea.select();
+                        document.execCommand('copy');
+                        document.body.removeChild(textArea);
+                        const popup = document.getElementById('copyPopup');
+                        popup.textContent = `Spell ID ${spellId} copied to clipboard!`;
+                        popup.classList.add('show');
+                        setTimeout(() => {
+                            popup.classList.remove('show');
+                        }, 2000);
+                    });
                 }
+            },
+            mounted() {
+                this.initializeLevelMatrix();
+                window.addEventListener('scroll', () => {
+                    if (!this.isScrolling) {
+                        this.applyScrollBlur();
+                    }
+                });
             }
-        }
-        
-        // Scroll to top of page
-        function scrollToTop() {
-            // Apply blur effect before scrolling
-            applyScrollBlur();
-            
-            window.scrollTo({
-                top: 0,
-                behavior: 'smooth'
-            });
-        }
-        
-        // Listen for manual scrolling to also apply blur effect
-        let scrollTimer;
-        window.addEventListener('scroll', () => {
-            // Only apply blur if this is manual scrolling (not from our functions)
-            if (!isScrolling) {
-                applyScrollBlur();
-            }
-        });
-        
-        function copySpellId(spellId) {
-            // Copy to clipboard
-            navigator.clipboard.writeText(spellId).then(function() {
-                // Show confirmation popup
-                const popup = document.getElementById('copyPopup');
-                popup.textContent = `Spell ID ${spellId} copied to clipboard!`;
-                popup.classList.add('show');
-                
-                // Hide popup after 2 seconds
-                setTimeout(function() {
-                    popup.classList.remove('show');
-                }, 2000);
-            }).catch(function(err) {
-                // Fallback for older browsers
-                const textArea = document.createElement('textarea');
-                textArea.value = spellId;
-                document.body.appendChild(textArea);
-                textArea.select();
-                document.execCommand('copy');
-                document.body.removeChild(textArea);
-                
-                // Show confirmation popup
-                const popup = document.getElementById('copyPopup');
-                popup.textContent = `Spell ID ${spellId} copied to clipboard!`;
-                popup.classList.add('show');
-                
-                setTimeout(function() {
-                    popup.classList.remove('show');
-                }, 2000);
-            });
-        }
-        
-        // Initialize everything when the page loads
-        document.addEventListener('DOMContentLoaded', function() {
-            initializeLevelMatrix();
-        });
+        }).mount('#app');
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- power individual class pages with Vue 3
- mention Vue-powered spell pages in README
- remove network fallbacks for class icons on index page
- clean up README install instructions

## Testing
- `python -m py_compile scrape_spells.py`
- `python -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_e_685419bfe64083229af0393623ebec3d