### PR TITLE
Fix spell display issues for multiple classes

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -60,8 +60,17 @@ def can_scrape_class(class_name):
 def get_spells(class_name):
     """Get spells for a specific class"""
     try:
-        # Normalize class name
-        class_name = class_name.title()
+        # Normalize class name - handle special cases
+        class_name_lower = class_name.lower()
+        
+        # Map common variations to correct case
+        class_name_map = {cls.lower(): cls for cls in CLASSES.keys()}
+        
+        if class_name_lower in class_name_map:
+            class_name = class_name_map[class_name_lower]
+        else:
+            # Fallback to title case for unknown names
+            class_name = class_name.title()
         
         if class_name not in CLASSES:
             logger.warning(f"Invalid class name requested: {class_name}")

--- a/src/views/ClassSpells.vue
+++ b/src/views/ClassSpells.vue
@@ -116,11 +116,6 @@
                   <span class="attribute-value">{{ spell.mana }}</span>
                 </div>
               </div>
-              
-              <div v-if="spell.effects" class="spell-description">
-                <span class="attribute-label">Effects:</span>
-                <p>{{ spell.effects }}</p>
-              </div>
             </div>
           </div>
         </div>
@@ -739,22 +734,6 @@ export default {
 .target-group { 
   background: rgba(168, 85, 247, 0.1) !important; 
   border-left-color: #a855f7 !important; 
-}
-
-.spell-description {
-  margin-top: 1rem;
-  padding-top: 1rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-.spell-description .attribute-label {
-  margin-bottom: 0.5rem;
-}
-
-.spell-description p {
-  color: var(--text-light);
-  font-style: italic;
-  line-height: 1.5;
 }
 
 .retry-button,


### PR DESCRIPTION
- Fix backend class name normalization to handle case-sensitive class names
- Remove unnecessary Effects section from spell cards for cleaner UI
- Add case-insensitive mapping for all class names in API endpoint
- Clean up unused CSS styles for removed Effects section

Resolves issues where certain classes were not displaying spell information due to incorrect case handling in the backend normalization logic.