### PR TITLE
Enhance NPC spell display and implement spell modal navigation

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3994,9 +3994,6 @@ def search_npcs():
                 nt.hp,
                 nt.mindmg,
                 nt.maxdmg,
-                nt.attack_speed,
-                nt.special_attacks,
-                nt.faction_id,
                 z.short_name as zone_short_name,
                 z.long_name as zone_long_name
             FROM npc_types nt
@@ -4035,9 +4032,6 @@ def search_npcs():
                 'hp': npc_data.get('hp', 0),
                 'mindmg': npc_data.get('mindmg', 0),
                 'maxdmg': npc_data.get('maxdmg', 0),
-                'attack_speed': npc_data.get('attack_speed', 100),
-                'special_attacks': npc_data.get('special_attacks', ''),
-                'faction_id': npc_data.get('faction_id', 0),
                 'zone_short_name': npc_data.get('zone_short_name', ''),
                 'zone_long_name': npc_data.get('zone_long_name', '')
             }
@@ -4105,9 +4099,6 @@ def get_npc_details(npc_id):
                     nt.mana,
                     nt.mindmg,
                     nt.maxdmg,
-                    nt.attack_speed,
-                    nt.special_attacks,
-                    nt.faction_id,
                     nt.texture,
                     nt.helmtexture,
                     nt.size,
@@ -4219,9 +4210,6 @@ def get_npc_details(npc_id):
                 'mana': npc_data.get('mana', 0),
                 'mindmg': npc_data.get('mindmg', 0),
                 'maxdmg': npc_data.get('maxdmg', 0),
-                'attack_speed': npc_data.get('attack_speed', 100),
-                'special_attacks': npc_data.get('special_attacks', ''),
-                'faction_id': npc_data.get('faction_id', 0),
                 'texture': npc_data.get('texture', 0),
                 'helmtexture': npc_data.get('helmtexture', 0),
                 'size': npc_data.get('size', 6),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,7 @@ import MainPage from '../views/MainPage.vue'
 import Home from '../views/Home.vue'
 import Items from '../views/Items.vue'
 import Spells from '../views/Spells.vue'
+import NPCs from '../views/NPCs.vue'
 
 // OAuth authentication components (lazy loaded)
 const AuthCallback = () => import('../views/AuthCallback.vue')
@@ -36,6 +37,11 @@ const routes = [
     path: '/spells',
     name: 'Spells',
     component: Spells
+  },
+  {
+    path: '/npcs',
+    name: 'NPCs',
+    component: NPCs
   },
   // OAuth authentication routes
   {

--- a/src/views/Items.vue
+++ b/src/views/Items.vue
@@ -855,7 +855,12 @@
                     </div>
                     
                     <div class="npcs-list">
-                      <div v-for="npc in zone.npcs" :key="npc.npc_id" class="npc-item">
+                      <div 
+                        v-for="npc in zone.npcs" 
+                        :key="npc.npc_id" 
+                        class="npc-item clickable"
+                        @click="openNPCModal(npc.npc_id, npc.npc_name)"
+                      >
                         <span class="npc-name">{{ npc.npc_name }}</span>
                         <span class="drop-chance">{{ npc.drop_chance }}%</span>
                       </div>
@@ -1263,7 +1268,7 @@
 
 <script setup>
 import { ref, onMounted, onBeforeUnmount, computed, nextTick } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { API_BASE_URL } from '../config/api'
 import LoadingModal from '../components/LoadingModal.vue'
 import { toastService } from '../services/toastService'
@@ -2404,8 +2409,19 @@ const getTopStatsDisplay = (item) => {
   return topStats
 }
 
-// Get route for query parameter checking
+// Navigation to NPC modal
+const openNPCModal = (npcId, npcName) => {
+  // Navigate to the NPCs page with the NPC modal opened
+  // We'll pass the NPC ID as a query parameter for the NPC modal to open
+  router.push({
+    name: 'NPCs',
+    query: { npc: npcId }
+  })
+}
+
+// Get route and router for navigation
 const route = useRoute()
+const router = useRouter()
 
 // Lifecycle
 onMounted(() => {
@@ -4377,10 +4393,20 @@ const handleClickOutside = (event) => {
   margin: 4px 0;
   background: rgba(255, 255, 255, 0.05);
   border-radius: 8px;
-  transition: background 0.2s ease;
+  transition: all 0.2s ease;
 }
 
-.npc-item:hover {
+.npc-item.clickable {
+  cursor: pointer;
+}
+
+.npc-item.clickable:hover {
+  background: rgba(102, 126, 234, 0.15);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.2);
+}
+
+.npc-item:not(.clickable):hover {
   background: rgba(255, 255, 255, 0.1);
 }
 

--- a/src/views/MainPage.vue
+++ b/src/views/MainPage.vue
@@ -137,6 +137,19 @@
         </div>
       </router-link>
       
+      <router-link 
+        to="/npcs"
+        class="nav-card npcs-nav"
+      >
+        <div class="nav-icon">
+          <div class="nav-icon-symbol">🧙</div>
+        </div>
+        <div class="nav-content">
+          <h3 class="nav-title">NPCs</h3>
+          <p class="nav-description">Search for NPCs, view their stats, spawn locations, and loot tables</p>
+        </div>
+      </router-link>
+      
       <div class="nav-card wiki-nav placeholder">
         <div class="nav-icon">
           <div class="nav-icon-symbol">📚</div>

--- a/src/views/NPCs.vue
+++ b/src/views/NPCs.vue
@@ -1,0 +1,1111 @@
+<template>
+  <div class="npcs-page">
+    <div class="page-header">
+      <h1>NPC Database</h1>
+      <p class="subtitle">Search and explore NPCs from the database</p>
+    </div>
+
+    <!-- Search Section -->
+    <div class="search-section">
+      <div class="search-container">
+        <div class="search-input-group">
+          <input
+            v-model="searchQuery"
+            @keyup.enter="performSearch()"
+            type="text"
+            placeholder="Search NPCs by name..."
+            class="search-input"
+          />
+          <button @click="performSearch()" class="search-button" :disabled="searching">
+            <i :class="searching ? 'fas fa-spinner fa-spin' : 'fas fa-search'"></i>
+            <span class="search-button-text">{{ searching ? 'Searching...' : 'Search' }}</span>
+          </button>
+        </div>
+        
+        <!-- Filters -->
+        <div class="filters-container">
+          <div class="filter-group">
+            <label for="level-min">Min Level:</label>
+            <input 
+              id="level-min"
+              v-model="minLevel" 
+              type="number" 
+              class="filter-input"
+              placeholder="1"
+              min="1"
+              max="255"
+            />
+          </div>
+          
+          <div class="filter-group">
+            <label for="level-max">Max Level:</label>
+            <input 
+              id="level-max"
+              v-model="maxLevel" 
+              type="number" 
+              class="filter-input"
+              placeholder="255"
+              min="1"
+              max="255"
+            />
+          </div>
+          
+          <div class="filter-group">
+            <label for="zone-filter">Zone:</label>
+            <select id="zone-filter" v-model="selectedZone" class="filter-select">
+              <option value="">All Zones</option>
+              <!-- Zone options will be populated dynamically -->
+            </select>
+          </div>
+          
+          <button @click="clearFilters" class="clear-filters-button">
+            <i class="fas fa-times"></i>
+            Clear Filters
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Loading Modal for Search -->
+    <LoadingModal 
+      :visible="searching" 
+      text="Searching NPCs..." 
+    />
+
+    <!-- Loading Modal for Pagination -->
+    <LoadingModal 
+      :visible="paginating" 
+      text="Loading more results..." 
+    />
+
+    <!-- Results Section -->
+    <div v-if="searchPerformed" class="results-section">
+      <div class="results-header">
+        <h2>Search Results</h2>
+        <div class="results-meta">
+          <span class="results-count">
+            Found {{ totalCount.toLocaleString() }} NPC{{ totalCount !== 1 ? 's' : '' }}
+          </span>
+          <span v-if="searchQuery" class="search-query">
+            for "{{ searchQuery }}"
+          </span>
+        </div>
+      </div>
+
+      <!-- Results List -->
+      <div v-if="searchResults.length > 0" class="npc-results">
+        <div class="npc-grid">
+          <div 
+            v-for="npc in searchResults" 
+            :key="npc.id"
+            @click="openNPCModal(npc)"
+            class="npc-card"
+          >
+            <div class="npc-card-header">
+              <h3 class="npc-name">{{ npc.name }}</h3>
+              <span class="npc-level">Level {{ npc.level }}</span>
+            </div>
+            <div class="npc-card-body">
+              <div class="npc-info">
+                <span class="npc-race">{{ getRaceName(npc.race) }}</span>
+                <span class="npc-class">{{ getClassName(npc.class) }}</span>
+              </div>
+              <div class="npc-stats">
+                <span class="npc-hp">{{ npc.hp?.toLocaleString() }} HP</span>
+                <span v-if="npc.damage" class="npc-damage">
+                  {{ npc.mindmg }}-{{ npc.maxdmg }} dmg
+                </span>
+              </div>
+              <div v-if="npc.zone_short_name" class="npc-zone">
+                Zone: {{ npc.zone_long_name || npc.zone_short_name }}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Pagination -->
+        <div v-if="totalPages > 1" class="pagination">
+          <button 
+            @click="goToPage(1)"
+            :disabled="currentPage === 1"
+            class="pagination-button"
+            title="First page"
+          >
+            <i class="fas fa-angle-double-left"></i>
+          </button>
+          
+          <button 
+            @click="goToPage(currentPage - 1)"
+            :disabled="currentPage === 1"
+            class="pagination-button"
+            title="Previous page"
+          >
+            <i class="fas fa-angle-left"></i>
+          </button>
+          
+          <span class="pagination-info">
+            Page {{ currentPage }} of {{ totalPages }}
+          </span>
+          
+          <button 
+            @click="goToPage(currentPage + 1)"
+            :disabled="currentPage === totalPages"
+            class="pagination-button"
+            title="Next page"
+          >
+            <i class="fas fa-angle-right"></i>
+          </button>
+          
+          <button 
+            @click="goToPage(totalPages)"
+            :disabled="currentPage === totalPages"
+            class="pagination-button"
+            title="Last page"
+          >
+            <i class="fas fa-angle-double-right"></i>
+          </button>
+        </div>
+      </div>
+
+      <!-- No Results -->
+      <div v-else class="no-results">
+        <div class="no-results-content">
+          <i class="fas fa-search"></i>
+          <h3>No NPCs Found</h3>
+          <p>Try adjusting your search criteria or filters.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- NPC Details Loading Modal -->
+    <LoadingModal 
+      :visible="loadingNPCDetails" 
+      text="Loading NPC details..." 
+      :full-screen="true" 
+    />
+
+    <!-- NPC Details Modal -->
+    <div v-if="selectedNPCDetail && !loadingNPCDetails" class="modal-overlay" @click="closeNPCModal">
+      <div class="modal-content npc-modal" @click.stop>
+        <div class="modal-header">
+          <div class="modal-header-content">
+            <div class="npc-header-info">
+              <h3>{{ selectedNPCDetail.name }}</h3>
+              <div class="npc-header-meta">
+                <span class="npc-id-badge">ID: {{ selectedNPCDetail.id }}</span>
+                <span class="level-badge">Level {{ selectedNPCDetail.level }}</span>
+                <span class="race-badge">{{ getRaceName(selectedNPCDetail.race) }}</span>
+                <span class="class-badge">{{ getClassName(selectedNPCDetail.class) }}</span>
+              </div>
+            </div>
+          </div>
+          <button @click="closeNPCModal" class="modal-close">
+            <i class="fas fa-times"></i>
+          </button>
+        </div>
+
+        <div class="modal-body">
+          <!-- Basic Information -->
+          <div class="detail-section">
+            <h4>Basic Information</h4>
+            <div class="info-grid">
+              <div class="info-row">
+                <span class="info-label">Full Name:</span>
+                <span class="info-value">{{ selectedNPCDetail.name }}</span>
+              </div>
+              <div v-if="selectedNPCDetail.lastname" class="info-row">
+                <span class="info-label">Last Name:</span>
+                <span class="info-value">{{ selectedNPCDetail.lastname }}</span>
+              </div>
+              <div class="info-row">
+                <span class="info-label">Level:</span>
+                <span class="info-value">{{ selectedNPCDetail.level }}</span>
+              </div>
+              <div class="info-row">
+                <span class="info-label">Race:</span>
+                <span class="info-value">{{ getRaceName(selectedNPCDetail.race) }}</span>
+              </div>
+              <div class="info-row">
+                <span class="info-label">Class:</span>
+                <span class="info-value">{{ getClassName(selectedNPCDetail.class) }}</span>
+              </div>
+              <div v-if="selectedNPCDetail.faction_id" class="info-row">
+                <span class="info-label">Main Faction:</span>
+                <span class="info-value">{{ selectedNPCDetail.faction_name || `Faction ${selectedNPCDetail.faction_id}` }}</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Combat Stats -->
+          <div class="detail-section">
+            <h4>Combat Stats</h4>
+            <div class="info-grid">
+              <div class="info-row">
+                <span class="info-label">Health Points:</span>
+                <span class="info-value">{{ selectedNPCDetail.hp?.toLocaleString() }}</span>
+              </div>
+              <div v-if="selectedNPCDetail.mindmg || selectedNPCDetail.maxdmg" class="info-row">
+                <span class="info-label">Damage:</span>
+                <span class="info-value">{{ selectedNPCDetail.mindmg }} to {{ selectedNPCDetail.maxdmg }}</span>
+              </div>
+              <div v-if="selectedNPCDetail.attack_speed" class="info-row">
+                <span class="info-label">Attack Speed:</span>
+                <span class="info-value">{{ selectedNPCDetail.attack_speed }}%</span>
+              </div>
+              <div v-if="selectedNPCDetail.special_attacks" class="info-row">
+                <span class="info-label">Special Attacks:</span>
+                <span class="info-value">{{ getSpecialAttacks(selectedNPCDetail.special_attacks) }}</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Spawn Locations -->
+          <div v-if="selectedNPCDetail.spawn_locations && selectedNPCDetail.spawn_locations.length > 0" class="detail-section">
+            <h4>This NPC spawns in</h4>
+            <div class="spawn-locations">
+              <div v-for="location in selectedNPCDetail.spawn_locations" :key="location.zone_short_name" class="spawn-location">
+                <strong>{{ location.zone_long_name || location.zone_short_name }}</strong>
+              </div>
+            </div>
+          </div>
+
+          <!-- Loot Drops (if any) -->
+          <div v-if="selectedNPCDetail.loot_drops && selectedNPCDetail.loot_drops.length > 0" class="detail-section">
+            <h4>When killed, this NPC drops</h4>
+            <div class="loot-drops">
+              <div v-for="drop in selectedNPCDetail.loot_drops" :key="drop.item_id" class="loot-item">
+                <div class="loot-item-info">
+                  <img 
+                    v-if="drop.icon" 
+                    :src="`/icons/items/${drop.icon}.gif`" 
+                    :alt="drop.item_name"
+                    @error="handleIconError"
+                    class="loot-item-icon"
+                  />
+                  <i v-else class="fas fa-cube loot-item-icon-placeholder"></i>
+                  <span class="loot-item-name">{{ drop.item_name }}</span>
+                  <span class="loot-probability">{{ drop.probability }}%</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Toast Notifications -->
+    <div class="toast-container">
+      <div v-for="toast in toasts" :key="toast.id" class="toast" :class="toast.type">
+        <i :class="getToastIcon(toast.type)"></i>
+        <div class="toast-content">
+          <div class="toast-title">{{ toast.title }}</div>
+          <div v-if="toast.message" class="toast-message">{{ toast.message }}</div>
+        </div>
+        <button @click="removeToast(toast.id)" class="toast-close">
+          <i class="fas fa-times"></i>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import axios from 'axios'
+import LoadingModal from '../components/LoadingModal.vue'
+
+// API configuration
+const API_BASE_URL = import.meta.env.VITE_BACKEND_URL || 
+  (import.meta.env.PROD ? 'https://eqdatascraper-backend-production.up.railway.app' : '')
+
+export default {
+  name: 'NPCs',
+  components: {
+    LoadingModal
+  },
+  
+  data() {
+    return {
+      // Search state
+      searchQuery: '',
+      searching: false,
+      searchPerformed: false,
+      searchResults: [],
+      totalCount: 0,
+      
+      // Pagination
+      currentPage: 1,
+      limit: 20,
+      paginating: false,
+      
+      // Filters
+      minLevel: '',
+      maxLevel: '',
+      selectedZone: '',
+      
+      // NPC details modal
+      selectedNPCDetail: null,
+      loadingNPCDetails: false,
+      
+      // Toast notifications
+      toasts: [],
+      
+      // EverQuest data mappings
+      raceNames: {
+        1: 'Human', 2: 'Barbarian', 3: 'Erudite', 4: 'Wood Elf', 5: 'High Elf', 6: 'Dark Elf',
+        7: 'Half Elf', 8: 'Dwarf', 9: 'Troll', 10: 'Ogre', 11: 'Halfling', 12: 'Gnome',
+        128: 'Iksar', 130: 'Vah Shir', 330: 'Froglok', 522: 'Drakkin'
+      },
+      
+      classNames: {
+        1: 'Warrior', 2: 'Cleric', 3: 'Paladin', 4: 'Ranger', 5: 'Shadow Knight', 6: 'Druid',
+        7: 'Monk', 8: 'Bard', 9: 'Rogue', 10: 'Shaman', 11: 'Necromancer', 12: 'Wizard',
+        13: 'Magician', 14: 'Enchanter', 15: 'Beastlord', 16: 'Berserker'
+      }
+    }
+  },
+  
+  computed: {
+    totalPages() {
+      return Math.ceil(this.totalCount / this.limit)
+    }
+  },
+  
+  methods: {
+    async performSearch() {
+      if (!this.searchQuery.trim() && !this.minLevel && !this.maxLevel && !this.selectedZone) {
+        this.showToast('Search Required', 'Please enter a search term or select filters.', 'warning')
+        return
+      }
+
+      this.searching = true
+      this.currentPage = 1
+      
+      try {
+        const params = {
+          q: this.searchQuery.trim(),
+          limit: this.limit,
+          offset: 0
+        }
+        
+        // Add filters
+        if (this.minLevel) params.min_level = this.minLevel
+        if (this.maxLevel) params.max_level = this.maxLevel
+        if (this.selectedZone) params.zone = this.selectedZone
+        
+        const response = await axios.get(`${API_BASE_URL}/api/npcs/search`, { params })
+        
+        this.searchResults = response.data.npcs || []
+        this.totalCount = response.data.total_count || 0
+        this.searchPerformed = true
+        
+      } catch (error) {
+        console.error('Error searching NPCs:', error)
+        this.showToast('Search Error', 'Failed to search NPCs. Please try again.', 'error')
+        this.searchResults = []
+        this.totalCount = 0
+        this.searchPerformed = true
+      } finally {
+        this.searching = false
+      }
+    },
+
+    async goToPage(page) {
+      if (page === this.currentPage || page < 1 || page > this.totalPages) return
+      
+      this.paginating = true
+      this.currentPage = page
+      
+      try {
+        const params = {
+          q: this.searchQuery.trim(),
+          limit: this.limit,
+          offset: (page - 1) * this.limit
+        }
+        
+        // Add filters
+        if (this.minLevel) params.min_level = this.minLevel
+        if (this.maxLevel) params.max_level = this.maxLevel
+        if (this.selectedZone) params.zone = this.selectedZone
+        
+        const response = await axios.get(`${API_BASE_URL}/api/npcs/search`, { params })
+        this.searchResults = response.data.npcs || []
+        
+      } catch (error) {
+        console.error('Error loading page:', error)
+        this.showToast('Loading Error', 'Failed to load page. Please try again.', 'error')
+      } finally {
+        this.paginating = false
+      }
+    },
+
+    clearFilters() {
+      this.minLevel = ''
+      this.maxLevel = ''
+      this.selectedZone = ''
+    },
+
+    async openNPCModal(npc) {
+      try {
+        // Disable body scrolling
+        document.body.style.overflow = 'hidden'
+        
+        // Start loading state
+        this.loadingNPCDetails = true
+        
+        // Fetch detailed NPC information
+        const response = await axios.get(`${API_BASE_URL}/api/npcs/${npc.id}/details`)
+        
+        // Combine basic NPC data with detailed information
+        this.selectedNPCDetail = { ...npc, ...response.data }
+        
+        // Stop loading state
+        this.loadingNPCDetails = false
+        
+      } catch (error) {
+        console.error('Error fetching NPC details:', error)
+        this.selectedNPCDetail = { ...npc }
+        this.loadingNPCDetails = false
+        this.showToast('Loading Error', 'Failed to load NPC details.', 'error')
+      }
+    },
+
+    closeNPCModal() {
+      this.selectedNPCDetail = null
+      this.loadingNPCDetails = false
+      // Re-enable body scrolling
+      document.body.style.overflow = ''
+    },
+
+    getRaceName(raceId) {
+      return this.raceNames[raceId] || `Race ${raceId}`
+    },
+
+    getClassName(classId) {
+      return this.classNames[classId] || `Class ${classId}`
+    },
+
+    getSpecialAttacks(specialAttacks) {
+      if (!specialAttacks || specialAttacks === '0') return 'None'
+      // This would need to be expanded based on EQEmu's special attack flags
+      return 'Various'
+    },
+
+    handleIconError(event) {
+      event.target.style.display = 'none'
+    },
+
+    // Toast notification methods
+    showToast(title, message = '', type = 'info') {
+      const id = Date.now() + Math.random()
+      this.toasts.push({ id, title, message, type })
+      
+      // Auto-remove after 5 seconds
+      setTimeout(() => {
+        this.removeToast(id)
+      }, 5000)
+    },
+
+    removeToast(id) {
+      const index = this.toasts.findIndex(t => t.id === id)
+      if (index > -1) {
+        this.toasts.splice(index, 1)
+      }
+    },
+
+    getToastIcon(type) {
+      switch (type) {
+        case 'success': return 'fa-check-circle'
+        case 'error': return 'fa-exclamation-circle'
+        case 'warning': return 'fa-exclamation-triangle'
+        case 'info': return 'fa-info-circle'
+        default: return 'fa-info-circle'
+      }
+    }
+  },
+
+  unmounted() {
+    // Ensure body scrolling is restored if component is destroyed while modal is open
+    document.body.style.overflow = ''
+  }
+}
+</script>
+
+<style scoped>
+/* Use the same styling patterns as Items.vue and Spells.vue */
+.npcs-page {
+  padding: 20px;
+  padding-top: 100px; /* Prevent logo overlap */
+  max-width: 1400px;
+  margin: 0 auto;
+  min-height: 100vh;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 40px;
+}
+
+.page-header h1 {
+  font-size: 3rem;
+  margin: 0 0 15px 0;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.subtitle {
+  font-size: 1.2rem;
+  color: #888;
+  margin: 0;
+}
+
+/* Search Section */
+.search-section {
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border-radius: 15px;
+  padding: 30px;
+  margin-bottom: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.search-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.search-input-group {
+  display: flex;
+  gap: 15px;
+  margin-bottom: 25px;
+}
+
+.search-input {
+  flex: 1;
+  padding: 15px 20px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
+  font-size: 1rem;
+  backdrop-filter: blur(5px);
+}
+
+.search-input::placeholder {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-button {
+  padding: 15px 25px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  transition: all 0.3s ease;
+}
+
+.search-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 25px rgba(102, 126, 234, 0.4);
+}
+
+.search-button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.filters-container {
+  display: flex;
+  gap: 20px;
+  align-items: end;
+  flex-wrap: wrap;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.filter-group label {
+  color: white;
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.filter-input, .filter-select {
+  padding: 10px 15px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
+  backdrop-filter: blur(5px);
+  min-width: 120px;
+}
+
+.filter-select option {
+  background: #2a2a2a;
+  color: white;
+}
+
+.clear-filters-button {
+  padding: 10px 20px;
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 8px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: all 0.3s ease;
+}
+
+.clear-filters-button:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+/* Results Section */
+.results-section {
+  margin-top: 30px;
+}
+
+.results-header {
+  margin-bottom: 25px;
+}
+
+.results-header h2 {
+  color: white;
+  margin: 0 0 10px 0;
+  font-size: 1.8rem;
+}
+
+.results-meta {
+  color: #ccc;
+  font-size: 1rem;
+}
+
+.results-count {
+  font-weight: 600;
+}
+
+.search-query {
+  font-style: italic;
+  opacity: 0.8;
+}
+
+/* NPC Grid */
+.npc-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  gap: 20px;
+  margin-bottom: 30px;
+}
+
+.npc-card {
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 12px;
+  padding: 20px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.npc-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.3);
+  border-color: rgba(102, 126, 234, 0.5);
+}
+
+.npc-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.npc-name {
+  color: white;
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.npc-level {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  padding: 4px 12px;
+  border-radius: 15px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.npc-card-body {
+  color: #ccc;
+}
+
+.npc-info {
+  display: flex;
+  gap: 15px;
+  margin-bottom: 10px;
+}
+
+.npc-race, .npc-class {
+  font-weight: 500;
+}
+
+.npc-stats {
+  display: flex;
+  gap: 15px;
+  margin-bottom: 10px;
+}
+
+.npc-hp, .npc-damage {
+  font-size: 0.9rem;
+}
+
+.npc-zone {
+  font-size: 0.85rem;
+  opacity: 0.8;
+}
+
+/* Modal Styles */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(5px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  padding: 20px;
+}
+
+.npc-modal {
+  background: rgba(30, 30, 30, 0.95);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 20px;
+  width: 100%;
+  max-width: 800px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.5);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 25px 30px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.npc-header-info h3 {
+  color: white;
+  margin: 0 0 10px 0;
+  font-size: 1.8rem;
+}
+
+.npc-header-meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.npc-id-badge, .level-badge, .race-badge, .class-badge {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  padding: 4px 12px;
+  border-radius: 15px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  color: #ccc;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 10px;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+}
+
+.modal-close:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
+}
+
+.modal-body {
+  padding: 30px;
+}
+
+.detail-section {
+  margin-bottom: 30px;
+}
+
+.detail-section h4 {
+  color: white;
+  margin: 0 0 15px 0;
+  font-size: 1.3rem;
+  border-bottom: 2px solid rgba(102, 126, 234, 0.5);
+  padding-bottom: 8px;
+}
+
+.info-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.info-label {
+  color: #ccc;
+  font-weight: 500;
+  min-width: 150px;
+}
+
+.info-value {
+  color: white;
+  font-weight: 400;
+  text-align: right;
+}
+
+.spawn-locations, .loot-drops {
+  display: grid;
+  gap: 10px;
+}
+
+.spawn-location {
+  background: rgba(255, 255, 255, 0.05);
+  padding: 12px 15px;
+  border-radius: 8px;
+  color: #ccc;
+}
+
+.loot-item {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 12px 15px;
+}
+
+.loot-item-info {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.loot-item-icon {
+  width: 24px;
+  height: 24px;
+  image-rendering: pixelated;
+}
+
+.loot-item-icon-placeholder {
+  width: 24px;
+  height: 24px;
+  color: #666;
+}
+
+.loot-item-name {
+  flex: 1;
+  color: white;
+  font-weight: 500;
+}
+
+.loot-probability {
+  color: #ccc;
+  font-size: 0.9rem;
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  margin-top: 30px;
+}
+
+.pagination-button {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: white;
+  padding: 10px 15px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.pagination-button:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.pagination-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.pagination-info {
+  color: #ccc;
+  padding: 0 15px;
+  font-weight: 500;
+}
+
+/* No Results */
+.no-results {
+  text-align: center;
+  padding: 60px 20px;
+  color: #ccc;
+}
+
+.no-results-content i {
+  font-size: 4rem;
+  margin-bottom: 20px;
+  opacity: 0.5;
+}
+
+.no-results-content h3 {
+  margin: 0 0 10px 0;
+  color: white;
+}
+
+/* Toast Notifications */
+.toast-container {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 2000;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.toast {
+  background: rgba(30, 30, 30, 0.95);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 12px;
+  padding: 15px 20px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 300px;
+  max-width: 400px;
+  color: white;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+  animation: slideInRight 0.3s ease;
+}
+
+.toast.success { border-left: 4px solid #10b981; }
+.toast.error { border-left: 4px solid #ef4444; }
+.toast.warning { border-left: 4px solid #f59e0b; }
+.toast.info { border-left: 4px solid #3b82f6; }
+
+.toast-content {
+  flex: 1;
+}
+
+.toast-title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.toast-message {
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
+.toast-close {
+  background: none;
+  border: none;
+  color: #ccc;
+  cursor: pointer;
+  padding: 5px;
+  border-radius: 4px;
+  transition: all 0.3s ease;
+}
+
+.toast-close:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
+}
+
+@keyframes slideInRight {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .npcs-page {
+    padding: 15px;
+    padding-top: 80px;
+  }
+  
+  .page-header h1 {
+    font-size: 2rem;
+  }
+  
+  .search-input-group {
+    flex-direction: column;
+  }
+  
+  .filters-container {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  
+  .npc-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .modal-overlay {
+    padding: 10px;
+  }
+  
+  .modal-header, .modal-body {
+    padding: 20px;
+  }
+  
+  .npc-header-meta {
+    flex-direction: column;
+    align-items: start;
+  }
+  
+  .info-row {
+    flex-direction: column;
+    align-items: start;
+    gap: 4px;
+  }
+  
+  .info-value {
+    text-align: left;
+  }
+}
+</style>

--- a/src/views/NPCs.vue
+++ b/src/views/NPCs.vue
@@ -123,24 +123,21 @@
             @click="openNPCModal(npc)"
             class="npc-row"
           >
-            <div class="npc-basic-info">
-              <div class="npc-name-level">
+            <div class="npc-main-info">
+              <div class="npc-name-section">
                 <h3 class="npc-name">{{ npc.name }}</h3>
-                <span class="npc-level">Level {{ npc.level }}</span>
-              </div>
-              <div class="npc-race-class">
-                <span class="npc-race">{{ getRaceName(npc.race) }}</span>
-                <span class="npc-class">{{ getClassName(npc.class) }}</span>
+                <div class="npc-details">
+                  <span class="npc-level">Level {{ npc.level }}</span>
+                  <span class="npc-separator">•</span>
+                  <span class="npc-race">{{ getRaceName(npc.race) }}</span>
+                  <span class="npc-separator">•</span>
+                  <span class="npc-class">{{ getClassName(npc.class) }}</span>
+                </div>
               </div>
             </div>
-            <div class="npc-stats-info">
-              <span class="npc-hp">{{ npc.hp?.toLocaleString() }} HP</span>
-              <span v-if="npc.mindmg || npc.maxdmg" class="npc-damage">
-                {{ npc.mindmg }}-{{ npc.maxdmg }} dmg
-              </span>
-            </div>
-            <div v-if="npc.zone_short_name" class="npc-zone-info">
-              {{ npc.zone_long_name || npc.zone_short_name }}
+            <div v-if="npc.zone_short_name" class="npc-zone-display">
+              <span class="zone-label">Zone:</span>
+              <span class="zone-name">{{ getFormattedZoneName(npc) }}</span>
             </div>
           </div>
         </div>
@@ -625,6 +622,23 @@ export default {
       return this.classNames[classId] || `Class ${classId}`
     },
 
+    getFormattedZoneName(npc) {
+      // Use long name if available, otherwise format short name
+      if (npc.zone_long_name && npc.zone_long_name.trim()) {
+        return npc.zone_long_name
+      }
+      
+      // Format short name: remove underscores, capitalize words
+      if (npc.zone_short_name) {
+        return npc.zone_short_name
+          .replace(/_/g, ' ')
+          .split(' ')
+          .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+          .join(' ')
+      }
+      
+      return 'Unknown Zone'
+    },
 
     handleIconError(event) {
       event.target.style.display = 'none'
@@ -888,7 +902,7 @@ export default {
 .npc-list {
   display: flex;
   flex-direction: column;
-  gap: 15px;
+  gap: 12px;
   margin-bottom: 30px;
 }
 
@@ -897,13 +911,13 @@ export default {
   backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 12px;
-  padding: 20px;
+  padding: 18px 24px;
   cursor: pointer;
   transition: all 0.3s ease;
-  display: grid;
-  grid-template-columns: 1fr auto auto;
-  gap: 20px;
+  display: flex;
+  justify-content: space-between;
   align-items: center;
+  gap: 20px;
 }
 
 .npc-row:hover {
@@ -912,55 +926,74 @@ export default {
   border-color: rgba(102, 126, 234, 0.5);
 }
 
-.npc-basic-info {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+.npc-main-info {
+  flex: 1;
+  min-width: 0; /* Allow text to truncate if needed */
 }
 
-.npc-name-level {
+.npc-name-section {
   display: flex;
-  align-items: center;
-  gap: 15px;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .npc-row .npc-name {
   color: white;
   margin: 0;
-  font-size: 1.2rem;
+  font-size: 1.1rem;
   font-weight: 600;
+  line-height: 1.2;
 }
 
-.npc-row .npc-level {
+.npc-details {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #ccc;
+  font-size: 0.9rem;
+}
+
+.npc-level {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
-  padding: 4px 12px;
-  border-radius: 15px;
-  font-size: 0.85rem;
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 0.8rem;
   font-weight: 600;
 }
 
-.npc-race-class {
-  display: flex;
-  gap: 15px;
-  color: #ccc;
-  font-size: 0.9rem;
+.npc-separator {
+  color: #666;
+  font-weight: bold;
 }
 
-.npc-stats-info {
+.npc-race, .npc-class {
+  color: #ccc;
+  font-weight: 500;
+}
+
+.npc-zone-display {
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  align-items: flex-end;
+  gap: 2px;
+  min-width: 120px;
   text-align: right;
-  color: #ccc;
-  font-size: 0.9rem;
 }
 
-.npc-zone-info {
-  color: #9ca3af;
-  font-size: 0.85rem;
-  text-align: right;
-  opacity: 0.8;
+.zone-label {
+  color: #888;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.zone-name {
+  color: #e5e7eb;
+  font-size: 0.9rem;
+  font-weight: 500;
+  line-height: 1.3;
 }
 
 /* NPC Grid View */
@@ -1465,14 +1498,17 @@ export default {
   }
   
   .npc-row {
-    grid-template-columns: 1fr;
-    gap: 15px;
-    text-align: left;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 16px 20px;
   }
   
-  .npc-stats-info,
-  .npc-zone-info {
+  .npc-zone-display {
+    align-self: stretch;
+    align-items: flex-start;
     text-align: left;
+    min-width: auto;
   }
   
   .modal-overlay {

--- a/src/views/NPCs.vue
+++ b/src/views/NPCs.vue
@@ -124,7 +124,7 @@
             class="npc-row"
           >
             <div class="npc-main-info">
-              <div class="npc-name-section">
+              <div class="npc-name-and-details">
                 <h3 class="npc-name">{{ npc.name }}</h3>
                 <div class="npc-details">
                   <span class="npc-level">Level {{ npc.level }}</span>
@@ -998,16 +998,16 @@ export default {
   backdrop-filter: blur(15px);
   border: 1px solid rgba(255, 255, 255, 0.25);
   border-radius: 16px;
-  padding: 28px 36px;
+  padding: 32px 40px;
   cursor: pointer;
   transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 32px;
+  gap: 40px;
   position: relative;
   overflow: hidden;
-  min-height: 76px;
+  min-height: 96px;
 }
 
 .npc-row::before {
@@ -1042,70 +1042,76 @@ export default {
   z-index: 1;
 }
 
-.npc-name-section {
+.npc-name-and-details {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
+  align-items: center;
+  gap: 24px;
+  flex: 1;
+  min-width: 0;
+  flex-wrap: wrap;
 }
 
 .npc-row .npc-name {
   color: #f8fafc;
   margin: 0;
-  font-size: 1.4rem;
+  font-size: 1.6rem;
   font-weight: 700;
-  line-height: 1.3;
+  line-height: 1.2;
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-  letter-spacing: 0.3px;
+  letter-spacing: 0.4px;
+  flex-shrink: 0;
 }
 
 .npc-details {
   display: flex;
   align-items: center;
-  gap: 14px;
-  font-size: 1rem;
+  gap: 18px;
+  font-size: 1.1rem;
+  flex-wrap: wrap;
 }
 
 .npc-level {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
-  padding: 6px 16px;
-  border-radius: 16px;
-  font-size: 0.9rem;
+  padding: 8px 20px;
+  border-radius: 18px;
+  font-size: 1rem;
   font-weight: 700;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
-  box-shadow: 0 2px 6px rgba(102, 126, 234, 0.3);
+  box-shadow: 0 3px 8px rgba(102, 126, 234, 0.4);
   border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .npc-separator {
   color: #64748b;
   font-weight: 600;
-  font-size: 0.8rem;
+  font-size: 0.9rem;
+  margin: 0 2px;
 }
 
 .npc-race {
   color: #94a3b8;
   font-weight: 600;
-  font-size: 1rem;
+  font-size: 1.1rem;
 }
 
 .npc-class-with-icon {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
 }
 
 .npc-class-icon {
-  width: 22px;
-  height: 22px;
+  width: 26px;
+  height: 26px;
   image-rendering: pixelated;
-  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.4));
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.4));
 }
 
 .npc-class {
   color: #cbd5e1;
   font-weight: 600;
-  font-size: 1rem;
+  font-size: 1.1rem;
 }
 
 .npc-zone-display {
@@ -1705,23 +1711,34 @@ export default {
   .npc-row {
     flex-direction: column;
     align-items: flex-start;
-    gap: 16px;
-    padding: 24px 26px;
+    gap: 20px;
+    padding: 26px 28px;
     min-height: auto;
   }
   
+  .npc-name-and-details {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+  
   .npc-row .npc-name {
-    font-size: 1.2rem;
+    font-size: 1.35rem;
   }
   
   .npc-details {
-    gap: 12px;
-    font-size: 0.9rem;
+    gap: 14px;
+    font-size: 1rem;
   }
   
   .npc-class-icon {
-    width: 20px;
-    height: 20px;
+    width: 24px;
+    height: 24px;
+  }
+  
+  .npc-level {
+    padding: 6px 16px;
+    font-size: 0.9rem;
   }
   
   .npc-zone-display {

--- a/src/views/NPCs.vue
+++ b/src/views/NPCs.vue
@@ -240,9 +240,52 @@
                 <span class="info-label">Health Points:</span>
                 <span class="info-value">{{ selectedNPCDetail.hp?.toLocaleString() }}</span>
               </div>
+              <div v-if="selectedNPCDetail.mana" class="info-row">
+                <span class="info-label">Mana:</span>
+                <span class="info-value">{{ selectedNPCDetail.mana?.toLocaleString() }}</span>
+              </div>
+              <div v-if="selectedNPCDetail.ac" class="info-row">
+                <span class="info-label">Armor Class:</span>
+                <span class="info-value">{{ selectedNPCDetail.ac }}</span>
+              </div>
               <div v-if="selectedNPCDetail.mindmg || selectedNPCDetail.maxdmg" class="info-row">
                 <span class="info-label">Damage:</span>
                 <span class="info-value">{{ selectedNPCDetail.mindmg }} to {{ selectedNPCDetail.maxdmg }}</span>
+              </div>
+              <div v-if="selectedNPCDetail.attack_speed" class="info-row">
+                <span class="info-label">Attack Speed:</span>
+                <span class="info-value">{{ selectedNPCDetail.attack_speed }}%</span>
+              </div>
+              <div v-if="selectedNPCDetail.attack_delay" class="info-row">
+                <span class="info-label">Attack Delay:</span>
+                <span class="info-value">{{ selectedNPCDetail.attack_delay }}</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Resistances -->
+          <div v-if="selectedNPCDetail.resistances && hasResistances" class="detail-section">
+            <h4>Resistances</h4>
+            <div class="info-grid">
+              <div v-if="selectedNPCDetail.resistances.magic" class="info-row">
+                <span class="info-label">Magic Resistance:</span>
+                <span class="info-value">{{ selectedNPCDetail.resistances.magic }}</span>
+              </div>
+              <div v-if="selectedNPCDetail.resistances.cold" class="info-row">
+                <span class="info-label">Cold Resistance:</span>
+                <span class="info-value">{{ selectedNPCDetail.resistances.cold }}</span>
+              </div>
+              <div v-if="selectedNPCDetail.resistances.disease" class="info-row">
+                <span class="info-label">Disease Resistance:</span>
+                <span class="info-value">{{ selectedNPCDetail.resistances.disease }}</span>
+              </div>
+              <div v-if="selectedNPCDetail.resistances.fire" class="info-row">
+                <span class="info-label">Fire Resistance:</span>
+                <span class="info-value">{{ selectedNPCDetail.resistances.fire }}</span>
+              </div>
+              <div v-if="selectedNPCDetail.resistances.poison" class="info-row">
+                <span class="info-label">Poison Resistance:</span>
+                <span class="info-value">{{ selectedNPCDetail.resistances.poison }}</span>
               </div>
             </div>
           </div>
@@ -253,6 +296,55 @@
             <div class="spawn-locations">
               <div v-for="location in selectedNPCDetail.spawn_locations" :key="location.zone_short_name" class="spawn-location">
                 <strong>{{ location.zone_long_name || location.zone_short_name }}</strong>
+              </div>
+            </div>
+          </div>
+
+          <!-- NPC Spells -->
+          <div v-if="selectedNPCDetail.spells && selectedNPCDetail.spells.length > 0" class="detail-section">
+            <h4>Spells cast by this NPC</h4>
+            <div class="npc-spells">
+              <div v-for="spell in selectedNPCDetail.spells" :key="spell.spell_id" class="spell-item">
+                <div class="spell-item-info">
+                  <img 
+                    v-if="spell.icon" 
+                    :src="`/icons/spells/${spell.icon}.gif`" 
+                    :alt="spell.spell_name"
+                    @error="handleIconError"
+                    class="spell-item-icon"
+                  />
+                  <i v-else class="fas fa-magic spell-item-icon-placeholder"></i>
+                  <div class="spell-details">
+                    <span class="spell-name">{{ spell.spell_name }}</span>
+                    <div class="spell-meta">
+                      <span v-if="spell.priority" class="spell-priority">Priority: {{ spell.priority }}</span>
+                      <span v-if="spell.recast_delay" class="spell-recast">Recast: {{ spell.recast_delay }}s</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Merchant Items -->
+          <div v-if="selectedNPCDetail.merchant_items && selectedNPCDetail.merchant_items.length > 0" class="detail-section">
+            <h4>Items sold by this merchant</h4>
+            <div class="merchant-items">
+              <div v-for="item in selectedNPCDetail.merchant_items" :key="item.item_id" class="merchant-item">
+                <div class="merchant-item-info">
+                  <img 
+                    v-if="item.icon" 
+                    :src="`/icons/items/${item.icon}.gif`" 
+                    :alt="item.item_name"
+                    @error="handleIconError"
+                    class="merchant-item-icon"
+                  />
+                  <i v-else class="fas fa-cube merchant-item-icon-placeholder"></i>
+                  <div class="merchant-details">
+                    <span class="merchant-item-name">{{ item.item_name }}</span>
+                    <span v-if="item.price" class="merchant-price">{{ item.price?.toLocaleString() }} copper</span>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -355,6 +447,12 @@ export default {
   computed: {
     totalPages() {
       return Math.ceil(this.totalCount / this.limit)
+    },
+    
+    hasResistances() {
+      if (!this.selectedNPCDetail || !this.selectedNPCDetail.resistances) return false
+      const res = this.selectedNPCDetail.resistances
+      return res.magic || res.cold || res.disease || res.fire || res.poison
     }
   },
   
@@ -917,6 +1015,107 @@ export default {
 
 .loot-probability {
   color: #ccc;
+  font-size: 0.9rem;
+}
+
+/* NPC Spells */
+.npc-spells {
+  display: grid;
+  gap: 10px;
+}
+
+.spell-item {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 12px 15px;
+}
+
+.spell-item-info {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.spell-item-icon {
+  width: 24px;
+  height: 24px;
+  image-rendering: pixelated;
+}
+
+.spell-item-icon-placeholder {
+  width: 24px;
+  height: 24px;
+  color: #666;
+}
+
+.spell-details {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.spell-name {
+  color: white;
+  font-weight: 500;
+}
+
+.spell-meta {
+  display: flex;
+  gap: 15px;
+  font-size: 0.85rem;
+  color: #ccc;
+}
+
+.spell-priority, .spell-recast {
+  color: #ccc;
+}
+
+/* Merchant Items */
+.merchant-items {
+  display: grid;
+  gap: 10px;
+}
+
+.merchant-item {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 12px 15px;
+}
+
+.merchant-item-info {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.merchant-item-icon {
+  width: 24px;
+  height: 24px;
+  image-rendering: pixelated;
+}
+
+.merchant-item-icon-placeholder {
+  width: 24px;
+  height: 24px;
+  color: #666;
+}
+
+.merchant-details {
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.merchant-item-name {
+  color: white;
+  font-weight: 500;
+}
+
+.merchant-price {
+  color: #ffd700;
+  font-weight: 600;
   font-size: 0.9rem;
 }
 

--- a/src/views/NPCs.vue
+++ b/src/views/NPCs.vue
@@ -1002,15 +1002,16 @@ export default {
   backdrop-filter: blur(15px);
   border: 1px solid rgba(255, 255, 255, 0.25);
   border-radius: 16px;
-  padding: 20px 26px;
+  padding: 28px 36px;
   cursor: pointer;
   transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 24px;
+  gap: 32px;
   position: relative;
   overflow: hidden;
+  min-height: 76px;
 }
 
 .npc-row::before {
@@ -1048,32 +1049,32 @@ export default {
 .npc-name-section {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
 }
 
 .npc-row .npc-name {
   color: #f8fafc;
   margin: 0;
-  font-size: 1.15rem;
+  font-size: 1.4rem;
   font-weight: 700;
-  line-height: 1.2;
+  line-height: 1.3;
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-  letter-spacing: 0.2px;
+  letter-spacing: 0.3px;
 }
 
 .npc-details {
   display: flex;
   align-items: center;
-  gap: 10px;
-  font-size: 0.9rem;
+  gap: 14px;
+  font-size: 1rem;
 }
 
 .npc-level {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
-  padding: 4px 12px;
-  border-radius: 14px;
-  font-size: 0.8rem;
+  padding: 6px 16px;
+  border-radius: 16px;
+  font-size: 0.9rem;
   font-weight: 700;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
   box-shadow: 0 2px 6px rgba(102, 126, 234, 0.3);
@@ -1083,54 +1084,55 @@ export default {
 .npc-separator {
   color: #64748b;
   font-weight: 600;
-  font-size: 0.7rem;
+  font-size: 0.8rem;
 }
 
 .npc-race {
   color: #94a3b8;
   font-weight: 600;
-  font-size: 0.88rem;
+  font-size: 1rem;
 }
 
 .npc-class-with-icon {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
 }
 
 .npc-class-icon {
-  width: 18px;
-  height: 18px;
+  width: 22px;
+  height: 22px;
   image-rendering: pixelated;
-  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.4));
 }
 
 .npc-class {
   color: #cbd5e1;
   font-weight: 600;
-  font-size: 0.88rem;
+  font-size: 1rem;
 }
 
 .npc-zone-display {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  min-width: 140px;
+  min-width: 180px;
   z-index: 1;
 }
 
 .zone-name {
   color: #e2e8f0;
-  font-size: 0.95rem;
+  font-size: 1.05rem;
   font-weight: 600;
   text-align: right;
-  line-height: 1.3;
+  line-height: 1.4;
   background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
-  padding: 6px 14px;
-  border-radius: 12px;
+  padding: 10px 18px;
+  border-radius: 14px;
   border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-  backdrop-filter: blur(8px);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(10px);
+  white-space: nowrap;
 }
 
 /* NPC Grid View */
@@ -1637,8 +1639,23 @@ export default {
   .npc-row {
     flex-direction: column;
     align-items: flex-start;
-    gap: 14px;
-    padding: 18px 22px;
+    gap: 16px;
+    padding: 24px 26px;
+    min-height: auto;
+  }
+  
+  .npc-row .npc-name {
+    font-size: 1.2rem;
+  }
+  
+  .npc-details {
+    gap: 12px;
+    font-size: 0.9rem;
+  }
+  
+  .npc-class-icon {
+    width: 20px;
+    height: 20px;
   }
   
   .npc-zone-display {
@@ -1649,6 +1666,8 @@ export default {
   
   .zone-name {
     text-align: left;
+    font-size: 0.95rem;
+    padding: 8px 14px;
   }
   
   .modal-overlay {

--- a/src/views/NPCs.vue
+++ b/src/views/NPCs.vue
@@ -229,10 +229,6 @@
                 <span class="info-label">Class:</span>
                 <span class="info-value">{{ getClassName(selectedNPCDetail.class) }}</span>
               </div>
-              <div v-if="selectedNPCDetail.faction_id" class="info-row">
-                <span class="info-label">Main Faction:</span>
-                <span class="info-value">{{ selectedNPCDetail.faction_name || `Faction ${selectedNPCDetail.faction_id}` }}</span>
-              </div>
             </div>
           </div>
 
@@ -247,14 +243,6 @@
               <div v-if="selectedNPCDetail.mindmg || selectedNPCDetail.maxdmg" class="info-row">
                 <span class="info-label">Damage:</span>
                 <span class="info-value">{{ selectedNPCDetail.mindmg }} to {{ selectedNPCDetail.maxdmg }}</span>
-              </div>
-              <div v-if="selectedNPCDetail.attack_speed" class="info-row">
-                <span class="info-label">Attack Speed:</span>
-                <span class="info-value">{{ selectedNPCDetail.attack_speed }}%</span>
-              </div>
-              <div v-if="selectedNPCDetail.special_attacks" class="info-row">
-                <span class="info-label">Special Attacks:</span>
-                <span class="info-value">{{ getSpecialAttacks(selectedNPCDetail.special_attacks) }}</span>
               </div>
             </div>
           </div>
@@ -484,11 +472,6 @@ export default {
       return this.classNames[classId] || `Class ${classId}`
     },
 
-    getSpecialAttacks(specialAttacks) {
-      if (!specialAttacks || specialAttacks === '0') return 'None'
-      // This would need to be expanded based on EQEmu's special attack flags
-      return 'Various'
-    },
 
     handleIconError(event) {
       event.target.style.display = 'none'

--- a/src/views/NPCs.vue
+++ b/src/views/NPCs.vue
@@ -131,7 +131,16 @@
                   <span class="npc-separator">•</span>
                   <span class="npc-race">{{ getRaceName(npc.race) }}</span>
                   <span class="npc-separator">•</span>
-                  <span class="npc-class">{{ getClassName(npc.class) }}</span>
+                  <div class="npc-class-with-icon">
+                    <img 
+                      v-if="getClassIcon(npc.class)" 
+                      :src="getClassIcon(npc.class)" 
+                      :alt="getClassName(npc.class)"
+                      class="npc-class-icon"
+                      @error="handleIconError"
+                    />
+                    <span class="npc-class">{{ getClassName(npc.class) }}</span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -156,7 +165,16 @@
             <div class="npc-card-body">
               <div class="npc-info">
                 <span class="npc-race">{{ getRaceName(npc.race) }}</span>
-                <span class="npc-class">{{ getClassName(npc.class) }}</span>
+                <div class="npc-class-with-icon">
+                  <img 
+                    v-if="getClassIcon(npc.class)" 
+                    :src="getClassIcon(npc.class)" 
+                    :alt="getClassName(npc.class)"
+                    class="npc-class-icon"
+                    @error="handleIconError"
+                  />
+                  <span class="npc-class">{{ getClassName(npc.class) }}</span>
+                </div>
               </div>
               <div class="npc-stats">
                 <span class="npc-hp">{{ npc.hp?.toLocaleString() }} HP</span>
@@ -480,11 +498,58 @@ export default {
       // Toast notifications
       toasts: [],
       
-      // EverQuest data mappings
+      // EverQuest race mappings (comprehensive list from EQEmu docs)
       raceNames: {
         1: 'Human', 2: 'Barbarian', 3: 'Erudite', 4: 'Wood Elf', 5: 'High Elf', 6: 'Dark Elf',
         7: 'Half Elf', 8: 'Dwarf', 9: 'Troll', 10: 'Ogre', 11: 'Halfling', 12: 'Gnome',
-        128: 'Iksar', 130: 'Vah Shir', 330: 'Froglok', 522: 'Drakkin'
+        13: 'Aviak', 14: 'Werewolf', 15: 'Brownie', 16: 'Centaur', 17: 'Golem', 18: 'Giant',
+        19: 'Trakanon', 20: 'Venril Sathir', 21: 'Evil Eye', 22: 'Beetle', 23: 'Kerra',
+        24: 'Fish', 25: 'Fairy', 26: 'Old Froglok', 27: 'Kedge', 28: 'Leech', 29: 'Spider',
+        30: 'Drachnid', 31: 'Corpse', 32: 'Quadruped', 33: 'Fly', 34: 'Black Bear',
+        35: 'Brown Bear', 36: 'Polar Bear', 37: 'Giant Clan Dwarf', 38: 'Clockwork Gnome',
+        39: 'Clockwork Boar', 40: 'Clockwork Bug', 41: 'Wisp', 42: 'Halfling', 43: 'Efreeti',
+        44: 'Vampire', 45: 'Amygdalan', 46: 'Dervish', 47: 'Sphinx', 48: 'Armadillo',
+        49: 'Clockwork Rat', 50: 'Scarecrow', 51: 'Skunk', 52: 'Snake', 53: 'Giant Rat',
+        54: 'Ratman', 55: 'Kobold', 56: 'Giant Spider', 57: 'Gnoll', 58: 'Minotaur',
+        59: 'Zombie', 60: 'Skeleton', 61: 'Barracuda', 62: 'Tunare', 63: 'Tiger',
+        64: 'Treant', 65: 'Vampire Bat', 66: 'Alligator', 67: 'Alligator2', 68: 'Avocet',
+        69: 'Bear Cub', 70: 'Caiman', 71: 'Crocodile', 72: 'Elemental', 73: 'Hippo',
+        74: 'Lizardman', 75: 'Lion', 76: 'Mammoth', 77: 'Raptor', 78: 'Rhino',
+        79: 'Sabertooth Cat', 80: 'Shark', 81: 'Terrorbird', 82: 'Rhino Beetle',
+        83: 'Unicorn', 84: 'Pegasus', 85: 'Djinn', 86: 'Invisible Man', 87: 'Iksar',
+        88: 'Scorpion', 89: 'Vah Shir', 90: 'Sarnak', 91: 'Draglock', 92: 'Lycanthrope',
+        93: 'Mosquito', 94: 'Rhinoceros', 95: 'Xalgoz', 96: 'Kunark Goblin', 97: 'Yak Man',
+        98: 'Faun', 99: 'Coldain', 100: 'Velious Dragon', 101: 'Hag', 102: 'Hippogriff',
+        103: 'Siren', 104: 'Frost Giant', 105: 'Storm Giant', 106: 'Ottermen',
+        107: 'Walrus', 108: 'Geonid', 109: 'Yakman', 110: 'Scythe Cat', 111: 'Shadel',
+        112: 'Shik Nar', 113: 'Rockhopper', 114: 'Underbulk', 115: 'Grimling',
+        116: 'Wyvern', 117: 'Wurm', 118: 'Devourer', 119: 'Iksar Citizen', 120: 'Forest Giant',
+        121: 'Boat', 122: 'Minor Illusion', 123: 'Tree', 124: 'Burynai', 125: 'Goo',
+        126: 'Spectral Sarnak', 127: 'Spectral Iksar', 128: 'Kunark Fish', 129: 'Iksar Scorpion',
+        130: 'Erollisi', 131: 'Tribunal', 132: 'Bertoxxulous', 133: 'Bristlebane',
+        134: 'Fay Drake', 135: 'Undead Sarnak', 136: 'Ratman', 137: 'Wyvern',
+        138: 'Necromancer', 139: 'Shadowman', 140: 'Khati Sha', 141: 'Skeletal Horse',
+        142: 'Chimera', 143: 'Kly', 144: 'Sludge', 145: 'Combination', 146: 'Bixie',
+        147: 'Centaur', 148: 'Drakkin', 149: 'Giant', 150: 'Werewolf', 151: 'Barbarian',
+        152: 'Vah Shir', 153: 'Alaran', 154: 'Sarnak', 155: 'Vampire', 156: 'Ayonae Ro',
+        157: 'Sullon Zek', 158: 'Banner', 159: 'Flag', 160: 'Rowboat', 161: 'Bear Trap',
+        162: 'Clockwork Rat', 163: 'Clockwork Spider', 164: 'Clockwork Gnome',
+        165: 'Wisp', 166: 'Ground Spawn', 167: 'Weaponrack', 168: 'Coffin', 169: 'Bones',
+        170: 'Jokester', 171: 'Nihil', 172: 'Troll', 173: 'Sarnak Spirit',
+        174: 'Iksar Spirit', 175: 'Fish', 176: 'Scorpion', 177: 'Erollisi Marr',
+        178: 'Tunare', 179: 'Bertoxxulous', 180: 'Tribunal', 181: 'Bristlebane',
+        182: 'Undead Froglok', 183: 'Knight of Pestilence', 184: 'Leech',
+        185: 'Swordfish', 186: 'Felguard', 187: 'Mammoth', 188: 'Eye', 189: 'Wasp',
+        190: 'Mermaid', 191: 'Harpie', 192: 'Fayguard', 193: 'Drixie', 194: 'Ghost Ship',
+        195: 'Clam', 196: 'Seahorse', 197: 'Dwarf Ghost', 198: 'Erudite Ghost',
+        199: 'Sabertooth Cat Spirit', 200: 'Wolf Elemental', 201: 'Gorgon',
+        202: 'Dragon Skeleton', 203: 'Innoruuk', 204: 'Unicorn', 205: 'Pegasus',
+        206: 'Djinn', 207: 'Invisible Man', 208: 'Iksar', 209: 'Scorpion',
+        210: 'Vah Shir', 211: 'Sarnak', 212: 'Draglock', 213: 'Drolvarg', 214: 'Mosquito',
+        215: 'Rhinoceros', 216: 'Xalgoz', 217: 'Kunark Goblin', 218: 'Yak Man',
+        219: 'Faun', 220: 'Coldain', 221: 'Velious Dragon', 222: 'Hag', 223: 'Hippogriff',
+        224: 'Siren', 225: 'Frost Giant', 226: 'Storm Giant', 227: 'Ottermen',
+        228: 'Walrus', 229: 'Geonid', 230: 'Yakman', 330: 'Froglok', 522: 'Drakkin'
       },
       
       classNames: {
@@ -619,6 +684,31 @@ export default {
 
     getClassName(classId) {
       return this.classNames[classId] || `Class ${classId}`
+    },
+
+    getClassIcon(classId) {
+      // Map class IDs to their icon file names (same as in spell pages)
+      const classIconMap = {
+        1: 'warrior',      // Warrior
+        2: 'cleric',       // Cleric
+        3: 'paladin',      // Paladin
+        4: 'ranger',       // Ranger
+        5: 'shadowknight', // Shadow Knight
+        6: 'druid',        // Druid
+        7: 'monk',         // Monk
+        8: 'bard',         // Bard
+        9: 'rogue',        // Rogue
+        10: 'shaman',      // Shaman
+        11: 'necromancer', // Necromancer
+        12: 'wizard',      // Wizard
+        13: 'magician',    // Magician
+        14: 'enchanter',   // Enchanter
+        15: 'beastlord',   // Beastlord
+        16: 'berserker'    // Berserker
+      }
+      
+      const iconName = classIconMap[classId]
+      return iconName ? `/icons/${iconName}.gif` : null
     },
 
     getFormattedZoneName(npc) {
@@ -1000,6 +1090,19 @@ export default {
   color: #94a3b8;
   font-weight: 600;
   font-size: 0.88rem;
+}
+
+.npc-class-with-icon {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.npc-class-icon {
+  width: 18px;
+  height: 18px;
+  image-rendering: pixelated;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
 }
 
 .npc-class {

--- a/src/views/NPCs.vue
+++ b/src/views/NPCs.vue
@@ -136,7 +136,6 @@
               </div>
             </div>
             <div v-if="npc.zone_short_name" class="npc-zone-display">
-              <span class="zone-label">Zone:</span>
               <span class="zone-name">{{ getFormattedZoneName(npc) }}</span>
             </div>
           </div>
@@ -902,98 +901,133 @@ export default {
 .npc-list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
   margin-bottom: 30px;
 }
 
 .npc-row {
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 12px;
-  padding: 18px 24px;
+  background: linear-gradient(135deg, 
+    rgba(255, 255, 255, 0.12) 0%, 
+    rgba(255, 255, 255, 0.08) 100%);
+  backdrop-filter: blur(15px);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 16px;
+  padding: 20px 26px;
   cursor: pointer;
-  transition: all 0.3s ease;
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 20px;
+  gap: 24px;
+  position: relative;
+  overflow: hidden;
+}
+
+.npc-row::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(135deg, 
+    rgba(102, 126, 234, 0.05) 0%, 
+    rgba(118, 75, 162, 0.05) 100%);
+  opacity: 0;
+  transition: opacity 0.4s ease;
 }
 
 .npc-row:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
-  border-color: rgba(102, 126, 234, 0.5);
+  transform: translateY(-3px) scale(1.01);
+  box-shadow: 
+    0 20px 40px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(102, 126, 234, 0.3);
+  border-color: rgba(102, 126, 234, 0.6);
+}
+
+.npc-row:hover::before {
+  opacity: 1;
 }
 
 .npc-main-info {
   flex: 1;
-  min-width: 0; /* Allow text to truncate if needed */
+  min-width: 0;
+  z-index: 1;
 }
 
 .npc-name-section {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
 .npc-row .npc-name {
-  color: white;
+  color: #f8fafc;
   margin: 0;
-  font-size: 1.1rem;
-  font-weight: 600;
+  font-size: 1.15rem;
+  font-weight: 700;
   line-height: 1.2;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  letter-spacing: 0.2px;
 }
 
 .npc-details {
   display: flex;
   align-items: center;
-  gap: 8px;
-  color: #ccc;
+  gap: 10px;
   font-size: 0.9rem;
 }
 
 .npc-level {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
-  padding: 3px 10px;
-  border-radius: 12px;
+  padding: 4px 12px;
+  border-radius: 14px;
   font-size: 0.8rem;
-  font-weight: 600;
+  font-weight: 700;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 6px rgba(102, 126, 234, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .npc-separator {
-  color: #666;
-  font-weight: bold;
+  color: #64748b;
+  font-weight: 600;
+  font-size: 0.7rem;
 }
 
-.npc-race, .npc-class {
-  color: #ccc;
-  font-weight: 500;
+.npc-race {
+  color: #94a3b8;
+  font-weight: 600;
+  font-size: 0.88rem;
+}
+
+.npc-class {
+  color: #cbd5e1;
+  font-weight: 600;
+  font-size: 0.88rem;
 }
 
 .npc-zone-display {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 2px;
-  min-width: 120px;
-  text-align: right;
-}
-
-.zone-label {
-  color: #888;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  font-weight: 600;
-  letter-spacing: 0.5px;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 140px;
+  z-index: 1;
 }
 
 .zone-name {
-  color: #e5e7eb;
-  font-size: 0.9rem;
-  font-weight: 500;
+  color: #e2e8f0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-align: right;
   line-height: 1.3;
+  background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
+  padding: 6px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(8px);
 }
 
 /* NPC Grid View */
@@ -1500,15 +1534,18 @@ export default {
   .npc-row {
     flex-direction: column;
     align-items: flex-start;
-    gap: 12px;
-    padding: 16px 20px;
+    gap: 14px;
+    padding: 18px 22px;
   }
   
   .npc-zone-display {
     align-self: stretch;
-    align-items: flex-start;
-    text-align: left;
+    justify-content: flex-start;
     min-width: auto;
+  }
+  
+  .zone-name {
+    text-align: left;
   }
   
   .modal-overlay {

--- a/src/views/NPCs.vue
+++ b/src/views/NPCs.vue
@@ -158,32 +158,28 @@
             @click="openNPCModal(npc)"
             class="npc-card"
           >
-            <div class="npc-card-header">
-              <h3 class="npc-name">{{ npc.name }}</h3>
-              <span class="npc-level">Level {{ npc.level }}</span>
-            </div>
-            <div class="npc-card-body">
-              <div class="npc-info">
-                <span class="npc-race">{{ getRaceName(npc.race) }}</span>
-                <div class="npc-class-with-icon">
-                  <img 
-                    v-if="getClassIcon(npc.class)" 
-                    :src="getClassIcon(npc.class)" 
-                    :alt="getClassName(npc.class)"
-                    class="npc-class-icon"
-                    @error="handleIconError"
-                  />
-                  <span class="npc-class">{{ getClassName(npc.class) }}</span>
+            <div class="npc-card-content">
+              <div class="npc-card-main">
+                <h3 class="npc-card-name">{{ npc.name }}</h3>
+                <div class="npc-card-details">
+                  <span class="npc-card-level">Level {{ npc.level }}</span>
+                  <span class="npc-card-separator">•</span>
+                  <span class="npc-card-race">{{ getRaceName(npc.race) }}</span>
+                  <span class="npc-card-separator">•</span>
+                  <div class="npc-card-class-with-icon">
+                    <img 
+                      v-if="getClassIcon(npc.class)" 
+                      :src="getClassIcon(npc.class)" 
+                      :alt="getClassName(npc.class)"
+                      class="npc-card-class-icon"
+                      @error="handleIconError"
+                    />
+                    <span class="npc-card-class">{{ getClassName(npc.class) }}</span>
+                  </div>
                 </div>
               </div>
-              <div class="npc-stats">
-                <span class="npc-hp">{{ npc.hp?.toLocaleString() }} HP</span>
-                <span v-if="npc.mindmg || npc.maxdmg" class="npc-damage">
-                  {{ npc.mindmg }}-{{ npc.maxdmg }} dmg
-                </span>
-              </div>
-              <div v-if="npc.zone_short_name" class="npc-zone">
-                Zone: {{ npc.zone_long_name || npc.zone_short_name }}
+              <div v-if="npc.zone_short_name" class="npc-card-zone-display">
+                <span class="npc-card-zone-name">{{ getFormattedZoneName(npc) }}</span>
               </div>
             </div>
           </div>
@@ -1138,77 +1134,147 @@ export default {
 /* NPC Grid View */
 .npc-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-  gap: 20px;
+  grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+  gap: 14px;
   margin-bottom: 30px;
 }
 
 .npc-card {
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 12px;
-  padding: 20px;
+  background: linear-gradient(135deg, 
+    rgba(255, 255, 255, 0.12) 0%, 
+    rgba(255, 255, 255, 0.08) 100%);
+  backdrop-filter: blur(15px);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 16px;
+  padding: 24px;
   cursor: pointer;
-  transition: all 0.3s ease;
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+  min-height: 120px;
+}
+
+.npc-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(135deg, 
+    rgba(102, 126, 234, 0.05) 0%, 
+    rgba(118, 75, 162, 0.05) 100%);
+  opacity: 0;
+  transition: opacity 0.4s ease;
 }
 
 .npc-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.3);
-  border-color: rgba(102, 126, 234, 0.5);
+  transform: translateY(-3px) scale(1.01);
+  box-shadow: 
+    0 20px 40px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(102, 126, 234, 0.3);
+  border-color: rgba(102, 126, 234, 0.6);
 }
 
-.npc-card-header {
+.npc-card:hover::before {
+  opacity: 1;
+}
+
+.npc-card-content {
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
-  align-items: center;
-  margin-bottom: 15px;
+  height: 100%;
+  gap: 16px;
+  z-index: 1;
+  position: relative;
 }
 
-.npc-name {
-  color: white;
+.npc-card-main {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.npc-card-name {
+  color: #f8fafc;
   margin: 0;
-  font-size: 1.2rem;
-  font-weight: 600;
+  font-size: 1.3rem;
+  font-weight: 700;
+  line-height: 1.3;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  letter-spacing: 0.3px;
 }
 
-.npc-level {
+.npc-card-details {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.95rem;
+  flex-wrap: wrap;
+}
+
+.npc-card-level {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
-  padding: 4px 12px;
-  border-radius: 15px;
+  padding: 5px 14px;
+  border-radius: 14px;
   font-size: 0.85rem;
+  font-weight: 700;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 6px rgba(102, 126, 234, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.npc-card-separator {
+  color: #64748b;
   font-weight: 600;
+  font-size: 0.75rem;
 }
 
-.npc-card-body {
-  color: #ccc;
+.npc-card-race {
+  color: #94a3b8;
+  font-weight: 600;
+  font-size: 0.95rem;
 }
 
-.npc-info {
+.npc-card-class-with-icon {
   display: flex;
-  gap: 15px;
-  margin-bottom: 10px;
+  align-items: center;
+  gap: 6px;
 }
 
-.npc-race, .npc-class {
-  font-weight: 500;
+.npc-card-class-icon {
+  width: 20px;
+  height: 20px;
+  image-rendering: pixelated;
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.4));
 }
 
-.npc-stats {
+.npc-card-class {
+  color: #cbd5e1;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.npc-card-zone-display {
   display: flex;
-  gap: 15px;
-  margin-bottom: 10px;
+  justify-content: center;
+  margin-top: auto;
 }
 
-.npc-hp, .npc-damage {
+.npc-card-zone-name {
+  color: #e2e8f0;
   font-size: 0.9rem;
-}
-
-.npc-zone {
-  font-size: 0.85rem;
-  opacity: 0.8;
+  font-weight: 600;
+  text-align: center;
+  line-height: 1.4;
+  background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
+  padding: 8px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(8px);
 }
 
 /* Modal Styles */

--- a/src/views/NPCs.vue
+++ b/src/views/NPCs.vue
@@ -113,6 +113,31 @@
         </div>
       </div>
 
+      <!-- Top Pagination -->
+      <div v-if="searchPerformed && totalPages > 1 && !searching && searchResults.length > 0" class="pagination pagination-top">
+        <button 
+          @click="changePage(currentPage - 1)"
+          :disabled="currentPage <= 1"
+          class="page-button"
+        >
+          <i class="fas fa-chevron-left"></i>
+          Previous
+        </button>
+        
+        <div class="page-info">
+          Page {{ currentPage }} of {{ totalPages }}
+        </div>
+        
+        <button 
+          @click="changePage(currentPage + 1)"
+          :disabled="currentPage >= totalPages"
+          class="page-button"
+        >
+          Next
+          <i class="fas fa-chevron-right"></i>
+        </button>
+      </div>
+
       <!-- Results Display -->
       <div v-if="searchResults.length > 0" :class="['npc-results', viewMode]">
         <!-- List View -->
@@ -125,7 +150,7 @@
           >
             <div class="npc-main-info">
               <div class="npc-name-and-details">
-                <h3 class="npc-name">{{ npc.name }}</h3>
+                <h3 class="npc-name">{{ cleanNPCName(npc.name) }}</h3>
                 <div class="npc-details">
                   <span class="npc-level">Level {{ npc.level }}</span>
                   <span class="npc-separator">•</span>
@@ -160,7 +185,7 @@
           >
             <div class="npc-card-content">
               <div class="npc-card-main">
-                <h3 class="npc-card-name">{{ npc.name }}</h3>
+                <h3 class="npc-card-name">{{ cleanNPCName(npc.name) }}</h3>
                 <div class="npc-card-details">
                   <span class="npc-card-level">Level {{ npc.level }}</span>
                   <span class="npc-card-separator">•</span>
@@ -186,45 +211,27 @@
         </div>
 
         <!-- Pagination -->
-        <div v-if="totalPages > 1" class="pagination">
+        <div v-if="searchPerformed && totalPages > 1 && !searching" class="pagination">
           <button 
-            @click="goToPage(1)"
-            :disabled="currentPage === 1"
-            class="pagination-button"
-            title="First page"
+            @click="changePage(currentPage - 1)"
+            :disabled="currentPage <= 1"
+            class="page-button"
           >
-            <i class="fas fa-angle-double-left"></i>
+            <i class="fas fa-chevron-left"></i>
+            Previous
           </button>
           
-          <button 
-            @click="goToPage(currentPage - 1)"
-            :disabled="currentPage === 1"
-            class="pagination-button"
-            title="Previous page"
-          >
-            <i class="fas fa-angle-left"></i>
-          </button>
-          
-          <span class="pagination-info">
+          <div class="page-info">
             Page {{ currentPage }} of {{ totalPages }}
-          </span>
+          </div>
           
           <button 
-            @click="goToPage(currentPage + 1)"
-            :disabled="currentPage === totalPages"
-            class="pagination-button"
-            title="Next page"
+            @click="changePage(currentPage + 1)"
+            :disabled="currentPage >= totalPages"
+            class="page-button"
           >
-            <i class="fas fa-angle-right"></i>
-          </button>
-          
-          <button 
-            @click="goToPage(totalPages)"
-            :disabled="currentPage === totalPages"
-            class="pagination-button"
-            title="Last page"
-          >
-            <i class="fas fa-angle-double-right"></i>
+            Next
+            <i class="fas fa-chevron-right"></i>
           </button>
         </div>
       </div>
@@ -250,14 +257,39 @@
     <div v-if="selectedNPCDetail && !loadingNPCDetails" class="modal-overlay" @click="closeNPCModal">
       <div class="modal-content npc-modal" @click.stop>
         <div class="modal-header">
-          <div class="modal-header-content">
-            <div class="npc-header-info">
-              <h3>{{ selectedNPCDetail.name }}</h3>
-              <div class="npc-header-meta">
-                <span class="npc-id-badge">ID: {{ selectedNPCDetail.id }}</span>
-                <span class="level-badge">Level {{ selectedNPCDetail.level }}</span>
-                <span class="race-badge">{{ getRaceName(selectedNPCDetail.race) }}</span>
-                <span class="class-badge">{{ getClassName(selectedNPCDetail.class) }}</span>
+          <div class="npc-header-main">
+            <div class="npc-title-section">
+              <div class="npc-icon-container">
+                <img 
+                  v-if="getClassIcon(selectedNPCDetail.class)" 
+                  :src="getClassIcon(selectedNPCDetail.class)" 
+                  :alt="getClassName(selectedNPCDetail.class)"
+                  class="npc-modal-class-icon"
+                  @error="handleIconError"
+                />
+                <i v-else class="fas fa-user-circle npc-modal-class-fallback"></i>
+              </div>
+              <div class="npc-title-info">
+                <h2 class="npc-modal-title">{{ cleanNPCName(selectedNPCDetail.name) }}</h2>
+                <div class="npc-subtitle">{{ getRaceName(selectedNPCDetail.race) }} {{ getClassName(selectedNPCDetail.class) }}</div>
+              </div>
+            </div>
+            <div class="npc-header-badges">
+              <div class="badge-group">
+                <div class="level-and-combat-row">
+                  <span class="level-badge">
+                    <i class="fas fa-star"></i> Level {{ selectedNPCDetail.level }}
+                  </span>
+                  <span class="health-badge">
+                    <i class="fas fa-heart"></i> {{ selectedNPCDetail.hp?.toLocaleString() }} HP
+                  </span>
+                  <span v-if="selectedNPCDetail.mana" class="mana-badge">
+                    <i class="fas fa-magic"></i> {{ selectedNPCDetail.mana?.toLocaleString() }} MP
+                  </span>
+                  <span v-if="selectedNPCDetail.mindmg || selectedNPCDetail.maxdmg" class="damage-badge">
+                    <i class="fas fa-sword"></i> {{ selectedNPCDetail.mindmg }}-{{ selectedNPCDetail.maxdmg }} DMG
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -267,122 +299,94 @@
         </div>
 
         <div class="modal-body">
-          <!-- Basic Information -->
-          <div class="detail-section">
-            <h4>Basic Information</h4>
-            <div class="info-grid">
-              <div class="info-row">
-                <span class="info-label">Full Name:</span>
-                <span class="info-value">{{ selectedNPCDetail.name }}</span>
+          <!-- Enhanced Stats Grid -->
+          <div class="stats-overview">
+            <div class="stat-card">
+              <div class="stat-icon">
+                <i class="fas fa-info-circle"></i>
               </div>
-              <div v-if="selectedNPCDetail.lastname" class="info-row">
-                <span class="info-label">Last Name:</span>
-                <span class="info-value">{{ selectedNPCDetail.lastname }}</span>
-              </div>
-              <div class="info-row">
-                <span class="info-label">Level:</span>
-                <span class="info-value">{{ selectedNPCDetail.level }}</span>
-              </div>
-              <div class="info-row">
-                <span class="info-label">Race:</span>
-                <span class="info-value">{{ getRaceName(selectedNPCDetail.race) }}</span>
-              </div>
-              <div class="info-row">
-                <span class="info-label">Class:</span>
-                <span class="info-value">{{ getClassName(selectedNPCDetail.class) }}</span>
-              </div>
-            </div>
-          </div>
-
-          <!-- Combat Stats -->
-          <div class="detail-section">
-            <h4>Combat Stats</h4>
-            <div class="info-grid">
-              <div class="info-row">
-                <span class="info-label">Health Points:</span>
-                <span class="info-value">{{ selectedNPCDetail.hp?.toLocaleString() }}</span>
-              </div>
-              <div v-if="selectedNPCDetail.mana" class="info-row">
-                <span class="info-label">Mana:</span>
-                <span class="info-value">{{ selectedNPCDetail.mana?.toLocaleString() }}</span>
-              </div>
-              <div v-if="selectedNPCDetail.ac" class="info-row">
-                <span class="info-label">Armor Class:</span>
-                <span class="info-value">{{ selectedNPCDetail.ac }}</span>
-              </div>
-              <div v-if="selectedNPCDetail.mindmg || selectedNPCDetail.maxdmg" class="info-row">
-                <span class="info-label">Damage:</span>
-                <span class="info-value">{{ selectedNPCDetail.mindmg }} to {{ selectedNPCDetail.maxdmg }}</span>
-              </div>
-              <div v-if="selectedNPCDetail.attack_speed" class="info-row">
-                <span class="info-label">Attack Speed:</span>
-                <span class="info-value">{{ selectedNPCDetail.attack_speed }}%</span>
-              </div>
-              <div v-if="selectedNPCDetail.attack_delay" class="info-row">
-                <span class="info-label">Attack Delay:</span>
-                <span class="info-value">{{ selectedNPCDetail.attack_delay }}</span>
+              <div class="stat-content">
+                <h4>Basic Information</h4>
+                <div class="stat-details">
+                  <div class="stat-row">
+                    <span class="stat-label">Full Name</span>
+                    <span class="stat-value">{{ cleanNPCName(selectedNPCDetail.name) }}</span>
+                  </div>
+                  <div v-if="selectedNPCDetail.lastname" class="stat-row">
+                    <span class="stat-label">Last Name</span>
+                    <span class="stat-value">{{ selectedNPCDetail.lastname }}</span>
+                  </div>
+                  <div class="stat-row">
+                    <span class="stat-label">Race</span>
+                    <span class="stat-value">{{ getRaceName(selectedNPCDetail.race) }}</span>
+                  </div>
+                  <div class="stat-row">
+                    <span class="stat-label">Class</span>
+                    <span class="stat-value">{{ getClassName(selectedNPCDetail.class) }}</span>
+                  </div>
+                  <div v-if="selectedNPCDetail.npc_faction_id" class="stat-row">
+                    <span class="stat-label">Main Faction</span>
+                    <span class="stat-value">{{ getFactionName(selectedNPCDetail.npc_faction_id) }}</span>
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
 
-          <!-- Resistances -->
-          <div v-if="selectedNPCDetail.resistances && hasResistances" class="detail-section">
-            <h4>Resistances</h4>
-            <div class="info-grid">
-              <div v-if="selectedNPCDetail.resistances.magic" class="info-row">
-                <span class="info-label">Magic Resistance:</span>
-                <span class="info-value">{{ selectedNPCDetail.resistances.magic }}</span>
+            <div v-if="selectedNPCDetail.special_attacks && selectedNPCDetail.special_attacks.length > 0" class="stat-card">
+              <div class="stat-icon">
+                <i class="fas fa-bolt"></i>
               </div>
-              <div v-if="selectedNPCDetail.resistances.cold" class="info-row">
-                <span class="info-label">Cold Resistance:</span>
-                <span class="info-value">{{ selectedNPCDetail.resistances.cold }}</span>
-              </div>
-              <div v-if="selectedNPCDetail.resistances.disease" class="info-row">
-                <span class="info-label">Disease Resistance:</span>
-                <span class="info-value">{{ selectedNPCDetail.resistances.disease }}</span>
-              </div>
-              <div v-if="selectedNPCDetail.resistances.fire" class="info-row">
-                <span class="info-label">Fire Resistance:</span>
-                <span class="info-value">{{ selectedNPCDetail.resistances.fire }}</span>
-              </div>
-              <div v-if="selectedNPCDetail.resistances.poison" class="info-row">
-                <span class="info-label">Poison Resistance:</span>
-                <span class="info-value">{{ selectedNPCDetail.resistances.poison }}</span>
+              <div class="stat-content">
+                <h4>Special Attacks</h4>
+                <div class="special-attacks-list">
+                  <div v-for="attack in selectedNPCDetail.special_attacks" :key="attack" class="special-attack-item">
+                    <i class="fas fa-angle-right special-attack-icon"></i>
+                    <span class="special-attack-name">{{ attack }}</span>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
 
           <!-- Spawn Locations -->
-          <div v-if="selectedNPCDetail.spawn_locations && selectedNPCDetail.spawn_locations.length > 0" class="detail-section">
-            <h4>This NPC spawns in</h4>
-            <div class="spawn-locations">
-              <div v-for="location in selectedNPCDetail.spawn_locations" :key="location.zone_short_name" class="spawn-location">
-                <strong>{{ location.zone_long_name || location.zone_short_name }}</strong>
+          <div v-if="uniqueSpawnZones.length > 0" class="content-section">
+            <div class="section-header">
+              <i class="fas fa-map-marker-alt section-icon"></i>
+              <h3>This NPC spawns in</h3>
+            </div>
+            <div class="zone-list">
+              <div v-for="zone in uniqueSpawnZones" :key="zone" class="zone-item">
+                <i class="fas fa-globe zone-icon"></i>
+                <span class="zone-name">{{ zone }}</span>
               </div>
             </div>
           </div>
 
           <!-- NPC Spells -->
-          <div v-if="selectedNPCDetail.spells && selectedNPCDetail.spells.length > 0" class="detail-section">
-            <h4>Spells cast by this NPC</h4>
-            <div class="npc-spells">
-              <div v-for="spell in selectedNPCDetail.spells" :key="spell.spell_id" class="spell-item">
-                <div class="spell-item-info">
+          <div v-if="selectedNPCDetail.spells && selectedNPCDetail.spells.length > 0" class="content-section">
+            <div class="section-header">
+              <i class="fas fa-magic section-icon"></i>
+              <h3>Spells cast by this NPC</h3>
+            </div>
+            <div class="npc-spells-grid">
+              <div 
+                v-for="spell in selectedNPCDetail.spells" 
+                :key="spell.spell_id" 
+                @click="openSpellModal(spell.spell_id, spell.spell_name)"
+                class="npc-spell-card"
+              >
+                <div class="npc-spell-icon-container">
                   <img 
-                    v-if="spell.icon" 
-                    :src="`/icons/spells/${spell.icon}.gif`" 
+                    v-if="spell.icon && spell.icon !== 0" 
+                    :src="`/icons/items/${spell.icon}.gif`" 
                     :alt="spell.spell_name"
                     @error="handleIconError"
-                    class="spell-item-icon"
+                    class="npc-spell-icon"
                   />
-                  <i v-else class="fas fa-magic spell-item-icon-placeholder"></i>
-                  <div class="spell-details">
-                    <span class="spell-name">{{ spell.spell_name }}</span>
-                    <div class="spell-meta">
-                      <span v-if="spell.priority" class="spell-priority">Priority: {{ spell.priority }}</span>
-                      <span v-if="spell.recast_delay" class="spell-recast">Recast: {{ spell.recast_delay }}s</span>
-                    </div>
-                  </div>
+                  <i v-else class="fas fa-magic npc-spell-icon-placeholder"></i>
+                </div>
+                <div class="npc-spell-info">
+                  <span class="npc-spell-name">{{ spell.spell_name }}</span>
                 </div>
               </div>
             </div>
@@ -412,21 +416,73 @@
           </div>
 
           <!-- Loot Drops (if any) -->
-          <div v-if="selectedNPCDetail.loot_drops && selectedNPCDetail.loot_drops.length > 0" class="detail-section">
-            <h4>When killed, this NPC drops</h4>
-            <div class="loot-drops">
-              <div v-for="drop in selectedNPCDetail.loot_drops" :key="drop.item_id" class="loot-item">
-                <div class="loot-item-info">
-                  <img 
-                    v-if="drop.icon" 
-                    :src="`/icons/items/${drop.icon}.gif`" 
-                    :alt="drop.item_name"
-                    @error="handleIconError"
-                    class="loot-item-icon"
-                  />
-                  <i v-else class="fas fa-cube loot-item-icon-placeholder"></i>
-                  <span class="loot-item-name">{{ drop.item_name }}</span>
-                  <span class="loot-probability">{{ drop.probability }}%</span>
+          <div v-if="selectedNPCDetail.loot_drops && selectedNPCDetail.loot_drops.length > 0" class="content-section">
+            <div class="section-header">
+              <div class="section-header-left">
+                <i class="fas fa-treasure-chest section-icon"></i>
+                <h3>When killed, this NPC drops</h3>
+              </div>
+              <button 
+                @click="toggleAllLootDrops" 
+                class="toggle-all-button"
+                :title="allLootDropsExpanded ? 'Collapse all loot drops' : 'Expand all loot drops'"
+              >
+                <i :class="['fas', allLootDropsExpanded ? 'fa-compress-alt' : 'fa-expand-alt']"></i>
+                <span>{{ allLootDropsExpanded ? 'Hide All' : 'Show All' }}</span>
+              </button>
+            </div>
+            <div class="loot-tables">
+              <div v-for="lootTable in selectedNPCDetail.loot_drops" :key="lootTable.loot_drop_id" class="loot-table">
+                <div 
+                  class="loot-table-header clickable" 
+                  @click="toggleLootDrop(lootTable.loot_drop_id)"
+                >
+                  <div class="loot-table-info">
+                    <div class="loot-table-primary">
+                      <span class="loot-table-label">With a probability of {{ lootTable.table_probability }}%</span>
+                      <span class="item-count-badge">{{ lootTable.items.length }} {{ lootTable.items.length === 1 ? 'item' : 'items' }}</span>
+                      <i :class="['fas', 'expansion-icon', isLootDropExpanded(lootTable.loot_drop_id) ? 'fa-chevron-down' : 'fa-chevron-right']"></i>
+                    </div>
+                    <div class="loot-table-mechanics">
+                      <span v-if="lootTable.multiplier > 1" class="multiplier-info">({{ lootTable.multiplier }} {{ lootTable.multiplier === 1 ? 'roll' : 'rolls' }})</span>
+                      <span v-else class="multiplier-info">(1 roll)</span>
+                      <span v-if="lootTable.droplimit > 0" class="droplimit-info">• Max {{ lootTable.droplimit }} {{ lootTable.droplimit === 1 ? 'item' : 'items' }}</span>
+                      <span v-else class="droplimit-info">• No limit</span>
+                      <span v-if="lootTable.mindrop > 0" class="mindrop-info">• Min {{ lootTable.mindrop }} guaranteed</span>
+                    </div>
+                  </div>
+                </div>
+                <div 
+                  v-if="isLootDropExpanded(lootTable.loot_drop_id)" 
+                  class="loot-items"
+                >
+                  <div 
+                    v-for="item in lootTable.items" 
+                    :key="item.item_id" 
+                    @click="openItemModal(item.item_id)"
+                    class="loot-item clickable"
+                  >
+                    <div class="loot-item-icon-container">
+                      <img 
+                        v-if="item.icon" 
+                        :src="`/icons/items/${item.icon}.gif`" 
+                        :alt="item.item_name"
+                        @error="handleIconError"
+                        class="loot-item-icon"
+                      />
+                      <i v-else class="fas fa-cube loot-item-icon-placeholder"></i>
+                    </div>
+                    <div class="loot-item-info">
+                      <div class="loot-item-name">{{ item.item_name }}</div>
+                      <div class="loot-item-chances">
+                        <span class="individual-chance">{{ item.item_chance }}%</span>
+                        <span class="chance-separator">•</span>
+                        <span class="overall-chance" :class="{'rare-drop': item.overall_probability < 5, 'common-drop': item.overall_probability >= 20}">
+                          {{ item.overall_probability }}% Overall
+                        </span>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -491,35 +547,37 @@ export default {
       selectedNPCDetail: null,
       loadingNPCDetails: false,
       
+      // Loot drop expansion state
+      expandedLootDrops: new Set(),
+      
       // Toast notifications
       toasts: [],
       
-      // EverQuest race mappings (comprehensive list from EQEmu docs)
+      // Accurate EverQuest race mappings from EQEmu documentation
       raceNames: {
         1: 'Human', 2: 'Barbarian', 3: 'Erudite', 4: 'Wood Elf', 5: 'High Elf', 6: 'Dark Elf',
         7: 'Half Elf', 8: 'Dwarf', 9: 'Troll', 10: 'Ogre', 11: 'Halfling', 12: 'Gnome',
         13: 'Aviak', 14: 'Werewolf', 15: 'Brownie', 16: 'Centaur', 17: 'Golem', 18: 'Giant',
-        19: 'Trakanon', 20: 'Venril Sathir', 21: 'Evil Eye', 22: 'Beetle', 23: 'Kerra',
-        24: 'Fish', 25: 'Fairy', 26: 'Old Froglok', 27: 'Kedge', 28: 'Leech', 29: 'Spider',
-        30: 'Drachnid', 31: 'Corpse', 32: 'Quadruped', 33: 'Fly', 34: 'Black Bear',
-        35: 'Brown Bear', 36: 'Polar Bear', 37: 'Giant Clan Dwarf', 38: 'Clockwork Gnome',
-        39: 'Clockwork Boar', 40: 'Clockwork Bug', 41: 'Wisp', 42: 'Halfling', 43: 'Efreeti',
-        44: 'Vampire', 45: 'Amygdalan', 46: 'Dervish', 47: 'Sphinx', 48: 'Armadillo',
-        49: 'Clockwork Rat', 50: 'Scarecrow', 51: 'Skunk', 52: 'Snake', 53: 'Giant Rat',
-        54: 'Ratman', 55: 'Kobold', 56: 'Giant Spider', 57: 'Gnoll', 58: 'Minotaur',
-        59: 'Zombie', 60: 'Skeleton', 61: 'Barracuda', 62: 'Tunare', 63: 'Tiger',
-        64: 'Treant', 65: 'Vampire Bat', 66: 'Alligator', 67: 'Alligator2', 68: 'Avocet',
-        69: 'Bear Cub', 70: 'Caiman', 71: 'Crocodile', 72: 'Elemental', 73: 'Hippo',
-        74: 'Lizardman', 75: 'Lion', 76: 'Mammoth', 77: 'Raptor', 78: 'Rhino',
-        79: 'Sabertooth Cat', 80: 'Shark', 81: 'Terrorbird', 82: 'Rhino Beetle',
-        83: 'Unicorn', 84: 'Pegasus', 85: 'Djinn', 86: 'Invisible Man', 87: 'Iksar',
-        88: 'Scorpion', 89: 'Vah Shir', 90: 'Sarnak', 91: 'Draglock', 92: 'Lycanthrope',
-        93: 'Mosquito', 94: 'Rhinoceros', 95: 'Xalgoz', 96: 'Kunark Goblin', 97: 'Yak Man',
-        98: 'Faun', 99: 'Coldain', 100: 'Velious Dragon', 101: 'Hag', 102: 'Hippogriff',
-        103: 'Siren', 104: 'Frost Giant', 105: 'Storm Giant', 106: 'Ottermen',
-        107: 'Walrus', 108: 'Geonid', 109: 'Yakman', 110: 'Scythe Cat', 111: 'Shadel',
-        112: 'Shik Nar', 113: 'Rockhopper', 114: 'Underbulk', 115: 'Grimling',
-        116: 'Wyvern', 117: 'Wurm', 118: 'Devourer', 119: 'Iksar Citizen', 120: 'Forest Giant',
+        19: 'Trakanon', 20: 'Venril Sathir', 21: 'Evil Eye', 22: 'Beetle', 23: 'Kerran',
+        24: 'Fish', 25: 'Fairy', 26: 'Froglok', 27: 'Froglok', 28: 'Fungusman', 29: 'Gargoyle',
+        30: 'Gasbag', 31: 'Gelatinous Cube', 32: 'Ghost', 33: 'Ghoul', 34: 'Bat',
+        35: 'Eel', 36: 'Rat', 37: 'Snake', 38: 'Spider', 39: 'Gnoll', 40: 'Goblin',
+        41: 'Gorilla', 42: 'Wolf', 43: 'Bear', 44: 'Guard', 45: 'Demi Lich', 46: 'Imp',
+        47: 'Griffin', 48: 'Kobold', 49: 'Dragon', 50: 'Lion',
+        51: 'Lion', 52: 'Lizard Man', 53: 'Mimic', 54: 'Minotaur', 55: 'Orc',
+        56: 'Beggar', 57: 'Pixie', 58: 'Drachnid', 59: 'Solusek Ro', 60: 'Goblin',
+        61: 'Skeleton', 62: 'Shark', 63: 'Tunare', 64: 'Tiger', 65: 'Treant',
+        66: 'Vampire', 67: 'Rallos Zek', 68: 'Human', 69: 'Tentacle Terror', 70: 'Will-O-Wisp',
+        71: 'Zombie', 72: 'Human', 73: 'Ship', 74: 'Launch', 75: 'Piranha',
+        76: 'Elemental', 77: 'Puma', 78: 'Dark Elf', 79: 'Erudite', 80: 'Bixie',
+        81: 'Reanimated Hand', 82: 'Halfling', 83: 'Scarecrow', 84: 'Skunk', 85: 'Snake Elemental',
+        86: 'Spectre', 87: 'Sphinx', 88: 'Armadillo', 89: 'Clockwork Gnome', 90: 'Drake',
+        91: 'Barbarian', 92: 'Alligator', 93: 'Troll', 94: 'Ogre', 95: 'Dwarf',
+        96: 'Cazic Thule', 97: 'Cockatrice', 98: 'Daisy Man', 99: 'Vampire', 100: 'Dervish',
+        101: 'Efreeti', 102: 'Tadpole', 103: 'Kedge', 104: 'Leech', 105: 'Swordfish',
+        106: 'Guard', 107: 'Mammoth', 108: 'Eye', 109: 'Wasp', 110: 'Mermaid',
+        111: 'Harpy', 112: 'Guard', 113: 'Drixie', 114: 'Ghost Ship', 115: 'Clam',
+        116: 'Seahorse', 117: 'Ghost', 118: 'Ghost', 119: 'Sabertooth', 120: 'Wolf',
         121: 'Boat', 122: 'Minor Illusion', 123: 'Tree', 124: 'Burynai', 125: 'Goo',
         126: 'Spectral Sarnak', 127: 'Spectral Iksar', 128: 'Kunark Fish', 129: 'Iksar Scorpion',
         130: 'Erollisi', 131: 'Tribunal', 132: 'Bertoxxulous', 133: 'Bristlebane',
@@ -545,7 +603,66 @@ export default {
         215: 'Rhinoceros', 216: 'Xalgoz', 217: 'Kunark Goblin', 218: 'Yak Man',
         219: 'Faun', 220: 'Coldain', 221: 'Velious Dragon', 222: 'Hag', 223: 'Hippogriff',
         224: 'Siren', 225: 'Frost Giant', 226: 'Storm Giant', 227: 'Ottermen',
-        228: 'Walrus', 229: 'Geonid', 230: 'Yakman', 330: 'Froglok', 522: 'Drakkin'
+        228: 'Walrus', 229: 'Geonid', 230: 'Yakman', 231: 'Scythe Cat', 232: 'Shadel',
+        233: 'Shik Nar', 234: 'Rockhopper', 235: 'Underbulk', 236: 'Grimling',
+        237: 'Wyvern', 238: 'Wurm', 239: 'Devourer', 240: 'Iksar Citizen',
+        241: 'Forest Giant', 242: 'Boat', 243: 'Minor Illusion', 244: 'Tree',
+        245: 'Burynai', 246: 'Goo', 247: 'Spectral Sarnak', 248: 'Spectral Iksar',
+        249: 'Kunark Fish', 250: 'Iksar Scorpion', 330: 'Froglok', 331: 'Troll', 332: 'Troll',
+        333: 'Troll', 334: 'Ghost', 335: 'Pirate', 336: 'Pirate', 337: 'Pirate',
+        338: 'Pirate', 339: 'Pirate', 340: 'Pirate', 367: 'Selyrah',
+        421: 'Powder Pet', 446: 'Bixie', 460: 'Corathus', 461: 'Coral', 462: 'Drachnid', 463: 'Drachnid Cocoon',
+        464: 'Fungus Patch', 465: 'Gargoyle', 466: 'Witheran', 467: 'Dark Lord', 468: 'Snake',
+        469: 'Evil Eye', 470: 'Minotaur', 471: 'Zombie', 472: 'Clockwork Boar', 473: 'Fairy',
+        474: 'Witheran', 475: 'Air Elemental', 476: 'Earth Elemental', 477: 'Fire Elemental',
+        478: 'Water Elemental', 479: 'Alligator', 480: 'Alligator', 481: 'Bear', 482: 'Scaled Wolf',
+        483: 'Wolf', 484: 'Spirit Wolf', 485: 'Skeleton', 486: 'Spectre', 487: 'Bolvirk',
+        488: 'Banshee', 489: 'Banshee', 490: 'Elddar', 491: 'Forest Giant', 492: 'Bone Golem',
+        493: 'Horse', 494: 'Pegasus', 495: 'Shambling Mound', 496: 'Scrykin', 497: 'Treant',
+        498: 'Vampire', 499: 'Ayonae Ro', 500: 'Sullon Zek', 501: 'Banner', 502: 'Flag',
+        503: 'Rowboat', 504: 'Bear Trap', 505: 'Clockwork Bomb', 506: 'Dynamite Keg',
+        507: 'Pressure Plate', 508: 'Puffer Spore', 509: 'Stone Ring', 510: 'Root Tentacle',
+        511: 'Runic Symbol', 512: 'Saltpetter Bomb', 513: 'Floating Skull', 514: 'Spike Trap',
+        515: 'Totem', 516: 'Web', 517: 'Wicker Basket', 518: 'Nightmare/Unicorn', 519: 'Horse',
+        520: 'Bixie', 521: 'Centaur', 522: 'Drakkin', 523: 'Giant', 524: 'Gnoll',
+        525: 'Griffin', 526: 'Giant Shade', 527: 'Harpy', 528: 'Mammoth', 529: 'Satyr',
+        530: 'Dragon', 531: 'Dragon', 532: 'Dyn\'Leth', 533: 'Boat', 534: 'Weapon Rack',
+        535: 'Armor Rack', 536: 'Honey Pot', 537: 'Jum Jum Bucket', 538: 'Toolbox',
+        539: 'Stone Jug', 540: 'Small Plant', 567: 'Campfire', 568: 'Brownie', 569: 'Dragon',
+        570: 'Exoskeleton', 571: 'Ghoul', 572: 'Clockwork Guardian', 573: 'Mantrap',
+        574: 'Minotaur', 575: 'Scarecrow', 576: 'Shade', 577: 'Rotocopter',
+        578: 'Tentacle Terror', 579: 'Wereorc', 580: 'Worg', 581: 'Wyvern',
+        582: 'Prismatic Dragon', 583: 'Shiknar', 584: 'Rockhopper', 585: 'Underbulk',
+        586: 'Grimling', 587: 'Vacuum Cleaner', 588: 'Evan Test', 589: 'Kahli Shah',
+        590: 'Owlbear', 591: 'Rhino Beetle', 592: 'Vampyre', 593: 'Earth Elemental',
+        594: 'Air Elemental', 595: 'Water Elemental', 596: 'Fire Elemental',
+        597: 'Wetfang Minnow', 598: 'Thought Horror', 599: 'Tegi', 600: 'Horse',
+        601: 'Pegasus', 602: 'Nightmare', 603: 'Unicorn', 604: 'Selyrah Mount',
+        605: 'Drakkin Mount', 606: 'Giant', 607: 'Chimera', 608: 'Kirin',
+        609: 'Puma', 610: 'Boulder', 611: 'Banner', 612: 'Elven Boat',
+        613: 'Gingerbread Man', 614: 'Gnomework', 615: 'Burynai',
+        616: 'Amygdalan', 617: 'Dervish Cutthroat', 618: 'Sphinx',
+        619: 'Tentacle Terror', 620: 'Wereorc', 621: 'Kobold', 622: 'Worg',
+        623: 'Rhino', 624: 'Raven', 625: 'Prismatic Dragon', 626: 'Diaku Corsair',
+        629: 'Phurzikon', 630: 'Dervish', 638: 'Banshee', 652: 'Ship', 653: 'Launch',
+        654: 'Prefab Ship', 657: 'Warship', 658: 'Invisible Man', 660: 'Air Elemental',
+        661: 'Earth Elemental', 662: 'Fire Elemental', 663: 'Water Elemental',
+        664: 'Alaran Sentry Stone', 665: 'Alaran Portal', 666: 'Cliknar Sentinel',
+        667: 'Cliknar Drone', 668: 'Cliknar Centurion', 669: 'Cliknar Assassin',
+        670: 'Cliknar Adept', 671: 'Cliknar Discordling', 672: 'Banshee', 673: 'Dervish',
+        674: 'Worg', 675: 'Catman', 676: 'Cactus', 677: 'Witheran', 678: 'Dark Elf',
+        680: 'Fairy', 681: 'Witheran', 682: 'Air Mephit', 683: 'Earth Mephit',
+        684: 'Fire Mephit', 685: 'Water Mephit', 686: 'Dream Mephit', 687: 'Nightmare Mephit',
+        688: 'Zebuxoruk', 689: 'Muramite Armor', 690: 'Muramite Weapon', 691: 'Apexus',
+        692: 'Aneuk', 693: 'Ukun', 694: 'Ixt', 695: 'Kyv', 696: 'Noc', 697: 'Ra`tuk',
+        698: 'Taneth', 699: 'Huvul', 700: 'Mutant Humanoid', 701: 'Mastruq', 702: 'Taelosian',
+        703: 'Discord Ship', 704: 'Stone Worker', 705: 'Hynid', 706: 'Turepta', 707: 'Alaran',
+        708: 'Sarnak', 709: 'Dragorn', 710: 'Murkglider', 711: 'Rat', 712: 'Bat',
+        713: 'Gelidran', 714: 'Discordling', 715: 'Girplan', 716: 'Minotaur',
+        717: 'Dragorn Box', 718: 'Runed Orb', 719: 'Dragon Bones', 720: 'Muramite Armor',
+        721: 'Crystal Spider', 722: 'Zek', 723: 'Luggald', 724: 'Luggald', 725: 'Trite',
+        726: 'Yareth', 727: 'Netherbian', 728: 'Akhevan', 729: 'Spire Spirit',
+        730: 'Sonic Wolf', 731: 'Ground Shaker', 732: 'Vah Shir Skeleton'
       },
       
       classNames: {
@@ -561,10 +678,34 @@ export default {
       return Math.ceil(this.totalCount / this.limit)
     },
     
-    hasResistances() {
-      if (!this.selectedNPCDetail || !this.selectedNPCDetail.resistances) return false
-      const res = this.selectedNPCDetail.resistances
-      return res.magic || res.cold || res.disease || res.fire || res.poison
+    
+    uniqueSpawnZones() {
+      if (!this.selectedNPCDetail || !this.selectedNPCDetail.spawn_locations) return []
+      
+      // Create a set to store unique zone names
+      const uniqueZones = new Set()
+      
+      this.selectedNPCDetail.spawn_locations.forEach(location => {
+        const zoneName = location.zone_long_name || location.zone_short_name
+        if (zoneName && zoneName.trim()) {
+          uniqueZones.add(zoneName.trim())
+        }
+      })
+      
+      // Convert set to sorted array
+      return Array.from(uniqueZones).sort()
+    },
+
+    allLootDropsExpanded() {
+      // Check if we have loot drops and if all are expanded
+      if (!this.selectedNPCDetail || !this.selectedNPCDetail.loot_drops || this.selectedNPCDetail.loot_drops.length === 0) {
+        return false
+      }
+      
+      // Return true if all loot drops are in the expanded set
+      return this.selectedNPCDetail.loot_drops.every(lootDrop => 
+        this.expandedLootDrops.has(lootDrop.loot_drop_id)
+      )
     }
   },
   
@@ -607,12 +748,23 @@ export default {
       }
     },
 
-    async goToPage(page) {
-      if (page === this.currentPage || page < 1 || page > this.totalPages) return
+    changePage(page) {
+      if (page < 1 || page > this.totalPages || page === this.currentPage) return
       
+      // Clear current results to show loading state
+      this.searchResults = []
+      
+      // Set paginating state
       this.paginating = true
+      
+      // Update current page
       this.currentPage = page
       
+      // Perform the search for the new page
+      this.performSearchWithPage(page)
+    },
+
+    async performSearchWithPage(page) {
       try {
         const params = {
           q: this.searchQuery.trim(),
@@ -647,6 +799,9 @@ export default {
         // Disable body scrolling
         document.body.style.overflow = 'hidden'
         
+        // Reset expanded loot drops for new NPC
+        this.expandedLootDrops.clear()
+        
         // Start loading state
         this.loadingNPCDetails = true
         
@@ -680,6 +835,18 @@ export default {
 
     getClassName(classId) {
       return this.classNames[classId] || `Class ${classId}`
+    },
+
+    getFactionName(factionId) {
+      // For now, return a placeholder - this could be expanded with faction data later
+      if (!factionId || factionId === 0) return 'No Faction'
+      return `Faction ${factionId}`
+    },
+
+    cleanNPCName(name) {
+      // Remove leading # from NPC names and clean up underscores
+      if (!name) return 'Unknown NPC'
+      return name.replace(/^#+/, '').replace(/_/g, ' ').trim()
     },
 
     getClassIcon(classId) {
@@ -729,6 +896,50 @@ export default {
       event.target.style.display = 'none'
     },
 
+    toggleLootDrop(lootDropId) {
+      if (this.expandedLootDrops.has(lootDropId)) {
+        this.expandedLootDrops.delete(lootDropId)
+      } else {
+        this.expandedLootDrops.add(lootDropId)
+      }
+    },
+
+    isLootDropExpanded(lootDropId) {
+      return this.expandedLootDrops.has(lootDropId)
+    },
+
+    toggleAllLootDrops() {
+      if (this.allLootDropsExpanded) {
+        // Collapse all - clear the Set
+        this.expandedLootDrops.clear()
+      } else {
+        // Expand all - add all loot drop IDs to the Set
+        if (this.selectedNPCDetail && this.selectedNPCDetail.loot_drops) {
+          this.selectedNPCDetail.loot_drops.forEach(lootDrop => {
+            this.expandedLootDrops.add(lootDrop.loot_drop_id)
+          })
+        }
+      }
+    },
+
+    openItemModal(itemId) {
+      // Navigate to the Items page with the item modal opened
+      // We'll pass the item ID as a query parameter (matching what Items.vue expects: 'item')
+      this.$router.push({
+        name: 'Items',
+        query: { item: itemId }
+      })
+    },
+
+    openSpellModal(spellId, spellName) {
+      // Navigate to the Spells page with the spell modal opened
+      // We'll pass the spell ID as a query parameter for the spell modal to open
+      this.$router.push({
+        name: 'Spells',
+        query: { spell: spellId }
+      })
+    },
+
     // Toast notification methods
     showToast(title, message = '', type = 'info') {
       const id = Date.now() + Math.random()
@@ -754,6 +965,23 @@ export default {
         case 'warning': return 'fa-exclamation-triangle'
         case 'info': return 'fa-info-circle'
         default: return 'fa-info-circle'
+      }
+    }
+  },
+
+  async mounted() {
+    // Check if there's an NPC query parameter to open automatically
+    if (this.$route.query.npc) {
+      const npcId = parseInt(this.$route.query.npc)
+      if (!isNaN(npcId)) {
+        try {
+          // Create a minimal NPC object with the ID to open the modal
+          const npc = { id: npcId, name: 'Loading...' }
+          await this.openNPCModal(npc)
+        } catch (error) {
+          console.error('Error auto-opening NPC modal:', error)
+          this.showToast('Error', 'Failed to load NPC details', 'error')
+        }
       }
     }
   },
@@ -998,7 +1226,7 @@ export default {
   backdrop-filter: blur(15px);
   border: 1px solid rgba(255, 255, 255, 0.25);
   border-radius: 16px;
-  padding: 32px 40px;
+  padding: 8px 40px;
   cursor: pointer;
   transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
@@ -1007,7 +1235,7 @@ export default {
   gap: 40px;
   position: relative;
   overflow: hidden;
-  min-height: 96px;
+  min-height: auto;
 }
 
 .npc-row::before {
@@ -1025,11 +1253,14 @@ export default {
 }
 
 .npc-row:hover {
-  transform: translateY(-3px) scale(1.01);
+  transform: translateY(-1px) scale(1.005);
   box-shadow: 
-    0 20px 40px rgba(0, 0, 0, 0.4),
-    0 0 0 1px rgba(102, 126, 234, 0.3);
-  border-color: rgba(102, 126, 234, 0.6);
+    0 8px 16px rgba(0, 0, 0, 0.25),
+    0 0 0 1px rgba(102, 126, 234, 0.2);
+  border-color: rgba(102, 126, 234, 0.4);
+  background: linear-gradient(135deg, 
+    rgba(255, 255, 255, 0.15) 0%, 
+    rgba(255, 255, 255, 0.10) 100%);
 }
 
 .npc-row:hover::before {
@@ -1098,12 +1329,12 @@ export default {
 .npc-class-with-icon {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
 }
 
 .npc-class-icon {
-  width: 26px;
-  height: 26px;
+  width: 65px;
+  height: 84.5px;
   image-rendering: pixelated;
   filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.4));
 }
@@ -1152,12 +1383,12 @@ export default {
   backdrop-filter: blur(15px);
   border: 1px solid rgba(255, 255, 255, 0.25);
   border-radius: 16px;
-  padding: 24px;
+  padding: 8px 16px;
   cursor: pointer;
   transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
   overflow: hidden;
-  min-height: 120px;
+  min-height: auto;
 }
 
 .npc-card::before {
@@ -1175,11 +1406,14 @@ export default {
 }
 
 .npc-card:hover {
-  transform: translateY(-3px) scale(1.01);
+  transform: translateY(-1px) scale(1.005);
   box-shadow: 
-    0 20px 40px rgba(0, 0, 0, 0.4),
-    0 0 0 1px rgba(102, 126, 234, 0.3);
-  border-color: rgba(102, 126, 234, 0.6);
+    0 8px 16px rgba(0, 0, 0, 0.25),
+    0 0 0 1px rgba(102, 126, 234, 0.2);
+  border-color: rgba(102, 126, 234, 0.4);
+  background: linear-gradient(135deg, 
+    rgba(255, 255, 255, 0.15) 0%, 
+    rgba(255, 255, 255, 0.10) 100%);
 }
 
 .npc-card:hover::before {
@@ -1251,8 +1485,8 @@ export default {
 }
 
 .npc-card-class-icon {
-  width: 20px;
-  height: 20px;
+  width: 50px;
+  height: 65px;
   image-rendering: pixelated;
   filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.4));
 }
@@ -1283,118 +1517,656 @@ export default {
   backdrop-filter: blur(8px);
 }
 
-/* Modal Styles */
+/* Enhanced Modal Styles */
 .modal-overlay {
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.8);
-  backdrop-filter: blur(5px);
+  background: rgba(0, 0, 0, 0.85);
+  backdrop-filter: blur(8px);
   display: flex;
   justify-content: center;
   align-items: center;
   z-index: 1000;
   padding: 20px;
+  animation: modalFadeIn 0.3s ease;
+}
+
+@keyframes modalFadeIn {
+  from {
+    opacity: 0;
+    backdrop-filter: blur(0px);
+  }
+  to {
+    opacity: 1;
+    backdrop-filter: blur(8px);
+  }
 }
 
 .npc-modal {
-  background: rgba(30, 30, 30, 0.95);
-  backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 20px;
+  background: linear-gradient(135deg, 
+    rgba(20, 20, 30, 0.98) 0%, 
+    rgba(25, 25, 35, 0.95) 100%);
+  backdrop-filter: blur(25px);
+  border: 1px solid rgba(102, 126, 234, 0.3);
+  border-radius: 24px;
   width: 100%;
-  max-width: 800px;
+  max-width: 1000px;
   max-height: 90vh;
   overflow-y: auto;
-  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.5);
+  box-shadow: 
+    0 30px 60px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(102, 126, 234, 0.1),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  animation: modalSlideIn 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes modalSlideIn {
+  from {
+    transform: translateY(-30px) scale(0.95);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
 }
 
 .modal-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  padding: 25px 30px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  align-items: flex-start;
+  padding: 30px 35px 25px 35px;
+  border-bottom: 1px solid rgba(102, 126, 234, 0.2);
+  background: linear-gradient(135deg, 
+    rgba(102, 126, 234, 0.08) 0%, 
+    rgba(118, 75, 162, 0.05) 100%);
+  border-radius: 24px 24px 0 0;
 }
 
-.npc-header-info h3 {
-  color: white;
-  margin: 0 0 10px 0;
-  font-size: 1.8rem;
-}
-
-.npc-header-meta {
+.npc-header-main {
   display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
+  align-items: center;
+  gap: 30px;
+  flex: 1;
 }
 
-.npc-id-badge, .level-badge, .race-badge, .class-badge {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
-  padding: 4px 12px;
-  border-radius: 15px;
-  font-size: 0.8rem;
+.npc-title-section {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.npc-icon-container {
+  position: relative;
+}
+
+.npc-modal-class-icon {
+  width: 80px;
+  height: 104px;
+  image-rendering: pixelated;
+  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.5));
+  border-radius: 8px;
+}
+
+.npc-modal-class-fallback {
+  font-size: 80px;
+  color: rgba(102, 126, 234, 0.6);
+  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.5));
+}
+
+.npc-title-info {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.npc-modal-title {
+  color: #f8fafc;
+  margin: 0;
+  font-size: 2.2rem;
+  font-weight: 800;
+  text-shadow: 0 3px 6px rgba(0, 0, 0, 0.4);
+  letter-spacing: 0.5px;
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.npc-subtitle {
+  color: #94a3b8;
+  font-size: 1.1rem;
   font-weight: 600;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
-.modal-close {
-  background: none;
-  border: none;
-  color: #ccc;
-  font-size: 1.5rem;
-  cursor: pointer;
-  padding: 10px;
-  border-radius: 50%;
-  transition: all 0.3s ease;
-}
-
-.modal-close:hover {
-  background: rgba(255, 255, 255, 0.1);
-  color: white;
-}
-
-.modal-body {
-  padding: 30px;
-}
-
-.detail-section {
-  margin-bottom: 30px;
-}
-
-.detail-section h4 {
-  color: white;
-  margin: 0 0 15px 0;
-  font-size: 1.3rem;
-  border-bottom: 2px solid rgba(102, 126, 234, 0.5);
-  padding-bottom: 8px;
-}
-
-.info-grid {
-  display: grid;
+.npc-header-badges {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   gap: 12px;
 }
 
-.info-row {
+.badge-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.npc-id-badge, .level-badge {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  padding: 8px 16px;
+  border-radius: 20px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  display: flex;
+}
+
+.level-and-combat-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.health-badge, .mana-badge, .damage-badge {
+  padding: 6px 12px;
+  border-radius: 16px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.health-badge {
+  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+  color: white;
+  box-shadow: 0 3px 8px rgba(239, 68, 68, 0.3);
+}
+
+.mana-badge {
+  background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);
+  color: white;
+  box-shadow: 0 3px 8px rgba(59, 130, 246, 0.3);
+}
+
+.damage-badge {
+  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+  color: white;
+  box-shadow: 0 3px 8px rgba(245, 158, 11, 0.3);
+}
+
+.modal-close {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: #cbd5e1;
+  font-size: 1.3rem;
+  cursor: pointer;
+  padding: 12px;
+  border-radius: 12px;
+  transition: all 0.3s ease;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(10px);
+}
+
+.modal-close:hover {
+  background: rgba(239, 68, 68, 0.2);
+  border-color: rgba(239, 68, 68, 0.4);
+  color: #fecaca;
+  transform: scale(1.05);
+  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.2);
+}
+
+.modal-body {
+  padding: 0 35px 35px 35px;
+}
+
+.stats-overview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+  margin-bottom: 30px;
+}
+
+.stat-card {
+  background: linear-gradient(135deg, 
+    rgba(255, 255, 255, 0.08) 0%, 
+    rgba(255, 255, 255, 0.04) 100%);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(102, 126, 234, 0.2);
+  border-radius: 16px;
+  padding: 20px;
+  transition: all 0.3s ease;
+}
+
+.stat-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(102, 126, 234, 0.15);
+  border-color: rgba(102, 126, 234, 0.4);
+}
+
+.stat-icon {
+  width: 40px;
+  height: 40px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 15px;
+  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+}
+
+.stat-icon i {
+  color: white;
+  font-size: 1.2rem;
+}
+
+.stat-content h4 {
+  color: #f8fafc;
+  margin: 0 0 15px 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.stat-details {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.stat-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 8px 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.info-label {
-  color: #ccc;
+.stat-row:last-child {
+  border-bottom: none;
+}
+
+.stat-label {
+  color: #cbd5e1;
   font-weight: 500;
-  min-width: 150px;
+  font-size: 0.95rem;
 }
 
-.info-value {
-  color: white;
-  font-weight: 400;
+.stat-value {
+  color: #f8fafc;
+  font-weight: 600;
   text-align: right;
+  font-size: 0.95rem;
+}
+
+.highlight-health {
+  color: #10b981;
+  text-shadow: 0 1px 2px rgba(16, 185, 129, 0.3);
+}
+
+.highlight-mana {
+  color: #3b82f6;
+  text-shadow: 0 1px 2px rgba(59, 130, 246, 0.3);
+}
+
+.highlight-damage {
+  color: #ef4444;
+  text-shadow: 0 1px 2px rgba(239, 68, 68, 0.3);
+}
+
+.special-attacks-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.special-attack-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  transition: all 0.3s ease;
+}
+
+.special-attack-item:hover {
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateX(4px);
+}
+
+.special-attack-icon {
+  color: #f59e0b;
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
+.special-attack-name {
+  color: #f8fafc;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.content-section {
+  margin-bottom: 30px;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 20px;
+  padding-bottom: 12px;
+  border-bottom: 2px solid rgba(102, 126, 234, 0.3);
+}
+
+.section-header-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.section-icon {
+  color: #667eea;
+  font-size: 1.3rem;
+}
+
+.section-header h3 {
+  color: #f8fafc;
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.toggle-all-button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.2);
+}
+
+.toggle-all-button:hover {
+  background: linear-gradient(135deg, #7c8df5 0%, #8b5cb3 100%);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+}
+
+.toggle-all-button i {
+  font-size: 0.8rem;
+}
+
+.zone-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.zone-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
+  padding: 12px 18px;
+  border-radius: 14px;
+  border: 1px solid rgba(102, 126, 234, 0.2);
+  transition: all 0.3s ease;
+  flex: 0 0 auto;
+}
+
+.zone-item:hover {
+  transform: translateY(-1px);
+  border-color: rgba(102, 126, 234, 0.4);
+  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.15);
+}
+
+.zone-icon {
+  color: #667eea;
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.zone-name {
+  color: #f8fafc;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.loot-tables {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.loot-table {
+  background: linear-gradient(135deg, 
+    rgba(255, 255, 255, 0.05) 0%, 
+    rgba(255, 255, 255, 0.02) 100%);
+  border: 1px solid rgba(102, 126, 234, 0.2);
+  border-radius: 16px;
+  overflow: hidden;
+  transition: all 0.3s ease;
+}
+
+.loot-table:hover {
+  border-color: rgba(102, 126, 234, 0.4);
+  box-shadow: 0 4px 20px rgba(102, 126, 234, 0.1);
+}
+
+.loot-table-header {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  padding: 12px 20px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.loot-table-header:hover {
+  background: linear-gradient(135deg, #7c8df5 0%, #8b5cb3 100%);
+}
+
+.loot-table-info {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.loot-table-primary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.loot-table-label {
+  color: white;
+  font-weight: 700;
+  font-size: 0.95rem;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+.item-count-badge {
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-shadow: none;
+}
+
+.expansion-icon {
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 0.9rem;
+  margin-left: auto;
+  transition: transform 0.2s ease;
+}
+
+.loot-table-mechanics {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.multiplier-info, .droplimit-info, .mindrop-info {
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.mindrop-info {
+  color: rgba(34, 197, 94, 0.9); /* Green color to indicate guaranteed drops */
+}
+
+.loot-items {
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.loot-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  background: linear-gradient(135deg, 
+    rgba(255, 255, 255, 0.08) 0%, 
+    rgba(255, 255, 255, 0.04) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  transition: all 0.3s ease;
+}
+
+.loot-item.clickable {
+  cursor: pointer;
+}
+
+.loot-item.clickable:hover {
+  transform: translateY(-1px);
+  border-color: rgba(102, 126, 234, 0.4);
+  box-shadow: 0 4px 15px rgba(102, 126, 234, 0.15);
+  background: linear-gradient(135deg, 
+    rgba(102, 126, 234, 0.1) 0%, 
+    rgba(118, 75, 162, 0.05) 100%);
+}
+
+.loot-item-icon-container {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.loot-item-icon {
+  width: 32px;
+  height: 32px;
+  image-rendering: pixelated;
+}
+
+.loot-item-icon-placeholder {
+  color: #64748b;
+  font-size: 1.2rem;
+}
+
+.loot-item-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.loot-item-name {
+  color: #f8fafc;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.3;
+  margin-bottom: 6px;
+  transition: color 0.3s ease;
+}
+
+.loot-item.clickable:hover .loot-item-name {
+  color: #e2e8f0;
+}
+
+.loot-item-chances {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.individual-chance {
+  background: linear-gradient(135deg, #64748b 0%, #475569 100%);
+  color: white;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 8px;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+.chance-separator {
+  color: #94a3b8;
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+.overall-chance {
+  font-size: 0.8rem;
+  font-weight: 700;
+  padding: 3px 10px;
+  border-radius: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+.overall-chance.rare-drop {
+  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+  color: white;
+  box-shadow: 0 2px 8px rgba(239, 68, 68, 0.3);
+}
+
+.overall-chance.common-drop {
+  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  color: white;
+  box-shadow: 0 2px 8px rgba(16, 185, 129, 0.3);
+}
+
+.overall-chance:not(.rare-drop):not(.common-drop) {
+  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+  color: white;
+  box-shadow: 0 2px 8px rgba(245, 158, 11, 0.3);
 }
 
 .spawn-locations, .loot-drops {
@@ -1445,56 +2217,66 @@ export default {
 }
 
 /* NPC Spells */
-.npc-spells {
+.npc-spells-grid {
   display: grid;
-  gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 16px;
+  margin-top: 16px;
 }
 
-.spell-item {
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 8px;
-  padding: 12px 15px;
+.npc-spell-card {
+  background: linear-gradient(135deg, 
+    rgba(255, 255, 255, 0.08) 0%, 
+    rgba(255, 255, 255, 0.04) 100%);
+  border: 1px solid rgba(102, 126, 234, 0.2);
+  border-radius: 12px;
+  padding: 16px;
+  transition: all 0.3s ease;
+  cursor: pointer;
 }
 
-.spell-item-info {
+.npc-spell-card:hover {
+  border-color: rgba(102, 126, 234, 0.4);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(102, 126, 234, 0.15);
+  background: linear-gradient(135deg, 
+    rgba(102, 126, 234, 0.12) 0%, 
+    rgba(118, 75, 162, 0.08) 100%);
+}
+
+.npc-spell-icon-container {
   display: flex;
+  justify-content: center;
   align-items: center;
-  gap: 12px;
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 12px;
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
-.spell-item-icon {
-  width: 24px;
-  height: 24px;
+.npc-spell-icon {
+  width: 48px;
+  height: 48px;
   image-rendering: pixelated;
 }
 
-.spell-item-icon-placeholder {
-  width: 24px;
-  height: 24px;
-  color: #666;
+.npc-spell-icon-placeholder {
+  color: rgba(102, 126, 234, 0.6);
+  font-size: 24px;
 }
 
-.spell-details {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+.npc-spell-info {
+  text-align: center;
 }
 
-.spell-name {
-  color: white;
-  font-weight: 500;
-}
-
-.spell-meta {
-  display: flex;
-  gap: 15px;
-  font-size: 0.85rem;
-  color: #ccc;
-}
-
-.spell-priority, .spell-recast {
-  color: #ccc;
+.npc-spell-name {
+  color: #f8fafc;
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.3;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
 }
 
 /* Merchant Items */
@@ -1545,38 +2327,70 @@ export default {
   font-size: 0.9rem;
 }
 
-/* Pagination */
+/* Enhanced Pagination */
 .pagination {
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 10px;
+  gap: 20px;
   margin-top: 30px;
+  margin-bottom: 40px;
+  padding: 20px;
+  background: linear-gradient(135deg, rgba(26, 32, 44, 0.9) 0%, rgba(45, 55, 72, 0.9) 100%);
+  backdrop-filter: blur(20px);
+  border-radius: 20px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3),
+              0 0 0 1px rgba(255, 255, 255, 0.1) inset;
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
-.pagination-button {
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.3);
+.pagination-top {
+  margin: 20px 0;
+  margin-bottom: 30px;
+}
+
+.page-button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
-  padding: 10px 15px;
-  border-radius: 8px;
+  border: none;
+  border-radius: 10px;
   cursor: pointer;
   transition: all 0.3s ease;
+  font-weight: 600;
+  font-size: 0.9rem;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);
 }
 
-.pagination-button:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.2);
+.page-button:hover:not(:disabled) {
+  background: linear-gradient(135deg, #764ba2 0%, #667eea 100%);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
 }
 
-.pagination-button:disabled {
+.page-button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+  background: linear-gradient(135deg, #4a5568 0%, #2d3748 100%);
+  transform: none;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
-.pagination-info {
-  color: #ccc;
+.page-info {
+  color: #e2e8f0;
+  font-weight: 600;
+  font-size: 1rem;
   padding: 0 15px;
-  font-weight: 500;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 8px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(10px);
 }
 
 /* No Results */
@@ -1732,8 +2546,8 @@ export default {
   }
   
   .npc-class-icon {
-    width: 24px;
-    height: 24px;
+    width: 60px;
+    height: 78px;
   }
   
   .npc-level {
@@ -1774,6 +2588,11 @@ export default {
   
   .info-value {
     text-align: left;
+  }
+  
+  .pagination {
+    flex-direction: column;
+    gap: 12px;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- Optimize NPC modal spell card layout by reducing width from 280px to 220px for better space utilization
- Fix spell icon display issues by correcting icon path from `/icons/spells/` to `/icons/items/`
- Implement automatic spell modal opening when navigating from NPC modal to Spells page
- Add comprehensive spell navigation functionality with route watching and error handling

## Technical Changes
- **NPC Modal Optimization**: Reduced spell card minimum width to allow additional columns in the spell grid
- **Icon Path Fix**: Corrected spell icon path to match the implementation used in Spells.vue page
- **Cross-Page Navigation**: Added `openSpellFromId()` method to fetch spell details by ID and auto-open modal
- **Route Integration**: Implemented Vue Router query parameter handling for seamless navigation
- **Error Handling**: Added comprehensive error handling and debug logging for troubleshooting

## Test Plan
- [x] Verify spell cards display in narrower format with additional columns in NPC modal
- [x] Confirm spell icons now display properly using corrected icon path
- [x] Test clicking spell cards in NPC modal navigates to Spells page
- [x] Verify spell modal automatically opens with correct spell details
- [x] Check route watching handles navigation changes while on Spells page
- [x] Confirm error handling works gracefully for missing or invalid spell IDs